### PR TITLE
Age stored health reports using FreshnessPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Initial deep audit and priority ledger under `docs/audits/`.
 - CI for compile, unit tests, and relative documentation link checks.
 
+### Changed
+
+- Stored health snapshots now apply `FreshnessPolicy` at sample time. A timestamp of `0` is `UNKNOWN`, not `HEALTHY`. Consecutive success/failure counts accumulate across reports.
+
 ### Safety
 
 - All motor, servo, hardware-recovery, and network-intervention features remain disabled by default.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Repository: **[The-Allsparks/BEACON](https://github.com/The-Allsparks/BEACON)**
 |------|--------|
 | **Version** | `0.1.0-SNAPSHOT` |
 | **Implemented phase** | **Phase 0** (vocabulary, immutable reports, fake clocks, manual registry, passive logging types) |
-| **Phase 1** | Designed; flag exists (`BeaconFeatureFlags.manualReports()`), not hardware-validated |
+| **Phase 1** | Manual reports + time-correlated sampling (`FreshnessPolicy` overlay); flag default off; not hardware-validated |
 | **Phases 2–10** | Designed / experimental / **disabled by default** |
 | **Active motor, servo, or network intervention** | **Disabled.** Do not enable without review and acceptance tests. |
 | **Driver Station early safe-stop** | **Not implemented.** No reliable supported public freshness API was verified. See [driver-link.md](docs/communications-health/driver-link.md). |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -3,10 +3,10 @@
 Living tracker for orchestrator selection. Update after each merged PR or when issue readiness changes.
 
 **Last updated:** 2026-08-17  
-**Audited commit:** `984f47a69e7c50f4bb9724fb5d626ddaab6201e4`  
+**Audited commit:** `56a85b5` (`main` after PR #28)  
 **Automatic merge:** false (human approval required)  
 **Max active implementation subagents:** 1  
-**Open implementation PR:** [#28](https://github.com/The-Allsparks/BEACON/pull/28) (draft → ready after audit docs land)
+**Open implementation PR:** issue #30 on `phase-1/30-freshness-sampling`
 
 ## Priority model
 
@@ -30,21 +30,21 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 ## Current selection
 
-Until PR #28 is merged, **do not start a second implementation PR**. Highest-priority next software issue: [#30](https://github.com/The-Allsparks/BEACON/issues/30) (audit A1/C1/T1).
+PR #28 is merged. Current implementation: [#30](https://github.com/The-Allsparks/BEACON/issues/30) freshness-aware sampling.
 
 | Issue | Priority | Readiness | Dependencies | Current status | Assigned subagent | Branch | Pull request | CI status | Merge status | Blocker | Next action |
 |-------|----------|-----------|--------------|----------------|-------------------|--------|--------------|-----------|--------------|---------|-------------|
-| [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | 1 | Ready for human review after audit docs | none | Draft PR | orchestrator | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | prior success; re-run after audit push | not authorized | `AUTOMATIC_MERGE=false` | Push audit docs; mark ready; request human merge |
-| [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | 2 | Technically ready; process-wait on #28 | #9, #10, PR #28 | Open | review until #28 resolves | — | — | — | — | Open implementation PR #28 | Subagent review first |
-| [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 3 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
-| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | 4 | Ready after #28 | none | Open | — | — | — | — | — | Open PR #28 | Follow-up PR |
-| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 5 | Blocked on hardware | PR #28 | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
-| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 6 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
-| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 7 | Not ready | #30 | Open | — | — | — | — | — | Time-honest registry | After #30 |
-| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 8 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
-| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 9 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
-| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 10 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
-| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 11 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
+| [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | done | merged | none | Merged to `main` | — | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | success | merged | none | Close #6–#9 |
+| [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | 1 | Ready | #9, #10 software | Implementing | orchestrator | `phase-1/30-freshness-sampling` | pending | pending | — | none | Test, open PR, wait for CI |
+| [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 2 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
+| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | 3 | Ready after #30 PR resolves | none | Open | — | — | — | — | — | Open #30 PR | Follow-up PR |
+| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 4 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
+| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 5 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
+| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 6 | Not ready | #30 | Open | — | — | — | — | — | Time-honest registry | After #30 merges |
+| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 7 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
+| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 8 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
+| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 9 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
+| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 10 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
 | [#29](https://github.com/The-Allsparks/BEACON/issues/29) Roadmap epic | tracking | n/a | none | Open | orchestrator | n/a | n/a | n/a | n/a | none | Update after each merge |
 
 ## Phase 0 issue hygiene (software vs remaining AC)
@@ -69,4 +69,4 @@ Implemented in PR #28 tree; close **after merge** if remaining ACs are explicitl
 - Do not merge without human approval.
 - Do not implement Phase 5–9 active behavior.
 - Do not claim hardware validation.
-- Do not open a second implementation PR while #28 is unresolved.
+- One implementation PR at a time.

--- a/docs/communications-health/architecture.md
+++ b/docs/communications-health/architecture.md
@@ -29,9 +29,26 @@ Do not invent unavailable latency or signal measurements.
 
 Collects reports without owning devices. Manual reports from ViDAR, MIMIC, AMPER, Pedro, and robot code are first-class. Removing BEACON means deleting `beacon.report(...)` calls; subsystems do not need rewrites.
 
+`snapshot()` and `get()` call `HealthSource.sample(nowNanos)`. For `FakeHealthSource`, that overlays `FreshnessPolicy` onto the last observation. Consecutive success/failure counts change only when a new report is accepted, not when a stored healthy report ages.
+
+Per-source override: `HealthRegistry.setFreshnessPolicy(id, policy)`. Auto-created sources use `FreshnessPolicy.manualReportsDefault()` (`40 / 80 / 250` ms) unless overridden. That default is for **manual and test reports**, not Driver Station packets.
+
 ## FreshnessPolicy
 
 Per-source thresholds for current / delayed / stale / lost. Camera frames, I²C readings, and Driver Station packets do not share timing.
+
+Sampling overlay (Phase 1):
+
+- Reporter `LOST` stays `LOST` (explicit loss wins) until a newer healthy report.
+- Reporter `UNKNOWN` stays `UNKNOWN`.
+- `lastValidTimestampNanos <= 0` on a non-lost report becomes `UNKNOWN` / `NEVER_OBSERVED`. A timestamp of `0` is not healthy.
+- A future timestamp becomes `UNKNOWN` / `INSUFFICIENT_EVIDENCE`.
+- Otherwise the snapshot is the worse of reporter state vs age (`HEALTHY` < `STALE` < `LOST`).
+- Age past the stale threshold (strictly greater than the inclusive bound) → `STALE` / `STALE_DATA`.
+- Age past the lost threshold → `LOST` / `TIMEOUT`.
+- `DELAYED` still maps to `LinkState.HEALTHY`. Phase 0 does not expose a delayed snapshot state.
+
+Do not invent latency when overlaying.
 
 ## PreflightInspector
 

--- a/docs/communications-health/glossary.md
+++ b/docs/communications-health/glossary.md
@@ -8,7 +8,7 @@
 | **Packet** | One datagram on a protocol. OpModes do not see Robocol packets. |
 | **Heartbeat** | Periodic “I am alive” message. FTC DS/RC heartbeats are **not** exposed to OpModes. |
 | **Keepalive** | Hub firmware timer; blinking blue LED means it expired. |
-| **Timeout** | Age beyond which data is treated as lost. Per-source. |
+| **Timeout** | Age beyond which data is treated as lost. Per-source. Aged `LOST` snapshots use reason `TIMEOUT`. |
 | **Latency** | Delay of a measured round trip. Leave empty if not measured. |
 | **Jitter** | Variation in packet or loop timing. Ordinary jitter must not trip safe-stop. |
 | **Packet loss** | Missing datagrams. Visible on FRC DS logs; not a public FTC OpMode API. |

--- a/docs/communications-health/phases.md
+++ b/docs/communications-health/phases.md
@@ -20,7 +20,7 @@ Allow ViDAR, MIMIC, AMPER, Pedro, and robot code to submit reports. BEACON only 
 
 **Acceptance:** reports are time-correlated; BEACON does not probe or restart devices; integration can be removed without subsystem rewrites; loop overhead is measured.
 
-**Status:** API present; flag default off.
+**Status:** time-correlated sampling implemented in the registry; flag default off; Control Hub overhead not measured.
 
 ## Phase 2 — Preflight inspection
 

--- a/docs/communications-health/testing.md
+++ b/docs/communications-health/testing.md
@@ -2,7 +2,7 @@
 
 ## Unit tests (Phase 0, implemented)
 
-Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks.
+Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`.
 
 ## Simulation tests (Phase 0, partial)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,29 +17,32 @@ See [phase-0-plan.md](../docs/communications-health/phase-0-plan.md).
 
 ```java
 BeaconSession beacon = BeaconSession.create(BeaconFeatureFlags.manualReports());
+FakeClock clock = new FakeClock(1L);
 beacon.report(HealthReport.healthy(
         LinkId.of("frontCamera"),
         FailureDomain.USB_CAMERA,
-        /* sourceTimestampNanos */ 0L,
+        clock.nanoTime(),
         "ViDAR"));
 beacon.report(HealthReport.healthy(
         LinkId.of("elevatorEncoder"),
         FailureDomain.SENSOR_BUS,
-        0L,
+        clock.nanoTime(),
         "MIMIC"));
 beacon.report(HealthReport.healthy(
         LinkId.of("batteryTelemetry"),
         FailureDomain.ELECTRICAL,
-        0L,
+        clock.nanoTime(),
         "AMPER"));
 beacon.report(HealthReport.healthy(
         LinkId.of("localization"),
         FailureDomain.SOFTWARE_LOOP,
-        0L,
+        clock.nanoTime(),
         "Pedro"));
 ```
 
-BEACON only stores and logs. It does not probe or restart devices.
+Use a positive source timestamp. `0` means never observed and snapshots as `UNKNOWN`, not `HEALTHY`. If you stop reporting, the registry ages the last valid time: delayed still maps to `HEALTHY`, then `STALE`, then `LOST`.
+
+BEACON only stores, ages, and logs. It does not probe or restart devices.
 
 ## Later phases
 

--- a/examples/passive-health-monitor/README.md
+++ b/examples/passive-health-monitor/README.md
@@ -20,6 +20,9 @@ public final class PassiveHealthMonitorExample {
                 LinkId.of("frontCamera"), FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
         System.out.println("sources=" + beacon.snapshot().size());
         System.out.println("events=" + beacon.logger().size());
+        System.out.println("state=" + beacon.snapshot().get(0).state());
+        clock.advanceMillis(251);
+        System.out.println("aged=" + beacon.snapshot().get(0).state());
         System.out.println("intervention=" + beacon.isInterventionEnabled());
     }
 }

--- a/src/main/java/org/allsparks/beacon/api/LinkHealth.java
+++ b/src/main/java/org/allsparks/beacon/api/LinkHealth.java
@@ -89,6 +89,20 @@ public final class LinkHealth {
         return confidence;
     }
 
+    /** Copy of this snapshot for overlay updates that must not invent latency. */
+    public Builder toBuilder() {
+        return builder(id)
+                .state(state)
+                .domain(domain)
+                .lastValidTimestampNanos(lastValidTimestampNanos)
+                .lastFailureTimestampNanos(lastFailureTimestampNanos)
+                .consecutiveSuccesses(consecutiveSuccesses)
+                .consecutiveFailures(consecutiveFailures)
+                .observedLatencyMs(observedLatencyMs)
+                .reason(reason)
+                .confidence(confidence);
+    }
+
     public static final class Builder {
         private final LinkId id;
         private LinkState state = LinkState.UNKNOWN;

--- a/src/main/java/org/allsparks/beacon/health/FakeHealthSource.java
+++ b/src/main/java/org/allsparks/beacon/health/FakeHealthSource.java
@@ -2,20 +2,31 @@ package org.allsparks.beacon.health;
 
 import java.util.Objects;
 import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.Freshness;
 import org.allsparks.beacon.api.HealthReport;
+import org.allsparks.beacon.api.LinkFailureReason;
 import org.allsparks.beacon.api.LinkHealth;
 import org.allsparks.beacon.api.LinkId;
 import org.allsparks.beacon.api.LinkState;
 
-/** Test double that returns a caller-assigned {@link LinkHealth}. */
+/**
+ * Manual-report source used before hardware adapters exist. Stores the last
+ * observation and overlays {@link FreshnessPolicy} at sample time.
+ */
 public final class FakeHealthSource implements HealthSource {
     private final LinkId id;
     private final FailureDomain domain;
+    private FreshnessPolicy policy;
     private LinkHealth current;
 
     public FakeHealthSource(LinkId id, FailureDomain domain) {
+        this(id, domain, FreshnessPolicy.manualReportsDefault());
+    }
+
+    public FakeHealthSource(LinkId id, FailureDomain domain, FreshnessPolicy policy) {
         this.id = Objects.requireNonNull(id, "id");
         this.domain = Objects.requireNonNull(domain, "domain");
+        this.policy = Objects.requireNonNull(policy, "policy");
         this.current = LinkHealth.unknown(id, domain);
     }
 
@@ -26,6 +37,14 @@ public final class FakeHealthSource implements HealthSource {
 
     public FailureDomain domain() {
         return domain;
+    }
+
+    public FreshnessPolicy policy() {
+        return policy;
+    }
+
+    public void setPolicy(FreshnessPolicy policy) {
+        this.policy = Objects.requireNonNull(policy, "policy");
     }
 
     public void setHealth(LinkHealth health) {
@@ -45,15 +64,70 @@ public final class FakeHealthSource implements HealthSource {
                 .reason(report.reason())
                 .confidence(report.confidence());
         if (state == LinkState.HEALTHY) {
-            builder.lastValidTimestampNanos(report.sourceTimestampNanos()).consecutiveSuccesses(1);
+            builder.lastValidTimestampNanos(report.sourceTimestampNanos())
+                    .lastFailureTimestampNanos(current.lastFailureTimestampNanos())
+                    .consecutiveSuccesses(current.consecutiveSuccesses() + 1)
+                    .consecutiveFailures(0);
         } else {
-            builder.lastFailureTimestampNanos(report.sourceTimestampNanos()).consecutiveFailures(1);
+            builder.lastFailureTimestampNanos(report.sourceTimestampNanos())
+                    .lastValidTimestampNanos(current.lastValidTimestampNanos())
+                    .consecutiveSuccesses(0)
+                    .consecutiveFailures(current.consecutiveFailures() + 1);
         }
         this.current = builder.build();
     }
 
     @Override
     public LinkHealth sample(long nowNanos) {
-        return current;
+        return overlay(current, nowNanos);
+    }
+
+    /**
+     * Reporter {@link LinkState#LOST} and {@link LinkState#UNKNOWN} stay as stored.
+     * Otherwise the snapshot is the worse of the last observation and the age of
+     * {@code lastValidTimestampNanos}. Aging does not change consecutive counts.
+     */
+    LinkHealth overlay(LinkHealth stored, long nowNanos) {
+        Objects.requireNonNull(stored, "stored");
+        LinkState reporter = stored.state();
+        if (reporter == LinkState.LOST || reporter == LinkState.UNKNOWN) {
+            return stored;
+        }
+        long lastValid = stored.lastValidTimestampNanos();
+        if (lastValid <= 0L) {
+            return stored.toBuilder()
+                    .state(LinkState.UNKNOWN)
+                    .reason(LinkFailureReason.NEVER_OBSERVED)
+                    .build();
+        }
+        if (nowNanos < lastValid) {
+            return stored.toBuilder()
+                    .state(LinkState.UNKNOWN)
+                    .reason(LinkFailureReason.INSUFFICIENT_EVIDENCE)
+                    .build();
+        }
+        Freshness freshness = policy.classify(lastValid, nowNanos);
+        LinkState aged = policy.toLinkState(freshness);
+        if (rank(reporter) >= rank(aged)) {
+            return stored;
+        }
+        LinkFailureReason reason = aged == LinkState.STALE
+                ? LinkFailureReason.STALE_DATA
+                : LinkFailureReason.TIMEOUT;
+        return stored.toBuilder().state(aged).reason(reason).build();
+    }
+
+    private static int rank(LinkState state) {
+        switch (state) {
+            case HEALTHY:
+                return 0;
+            case STALE:
+                return 1;
+            case LOST:
+                return 2;
+            case UNKNOWN:
+            default:
+                return -1;
+        }
     }
 }

--- a/src/main/java/org/allsparks/beacon/health/FreshnessPolicy.java
+++ b/src/main/java/org/allsparks/beacon/health/FreshnessPolicy.java
@@ -31,6 +31,14 @@ public final class FreshnessPolicy {
         return new FreshnessPolicy(delayedMs * 1_000_000L, staleMs * 1_000_000L, lostMs * 1_000_000L);
     }
 
+    /**
+     * Default for manual and test reports. Not a Driver Station packet budget.
+     * Matches the desktop jitter simulation windows (40 / 80 / 250 ms).
+     */
+    public static FreshnessPolicy manualReportsDefault() {
+        return ofMillis(40, 80, 250);
+    }
+
     public Freshness classify(long lastValidTimestampNanos, long nowNanos) {
         if (lastValidTimestampNanos <= 0L) {
             return Freshness.UNKNOWN;

--- a/src/main/java/org/allsparks/beacon/health/HealthRegistry.java
+++ b/src/main/java/org/allsparks/beacon/health/HealthRegistry.java
@@ -16,20 +16,51 @@ import org.allsparks.beacon.clock.BeaconClock;
 /**
  * Collects health reports without owning the underlying devices.
  * Manual reports from ViDAR, MIMIC, AMPER, Pedro, or robot code are stored
- * before automatic adapters exist.
+ * before automatic adapters exist. Sampling applies {@link FreshnessPolicy}.
  */
 public final class HealthRegistry {
     private final BeaconClock clock;
+    private final FreshnessPolicy defaultPolicy;
     private final Map<LinkId, HealthSource> sources = new LinkedHashMap<>();
     private final Map<LinkId, HealthReport> lastReports = new LinkedHashMap<>();
+    private final Map<LinkId, FreshnessPolicy> policies = new LinkedHashMap<>();
 
     public HealthRegistry(BeaconClock clock) {
+        this(clock, FreshnessPolicy.manualReportsDefault());
+    }
+
+    public HealthRegistry(BeaconClock clock, FreshnessPolicy defaultPolicy) {
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.defaultPolicy = Objects.requireNonNull(defaultPolicy, "defaultPolicy");
+    }
+
+    public FreshnessPolicy defaultPolicy() {
+        return defaultPolicy;
+    }
+
+    /**
+     * Per-source override. Applies immediately when the id already has a
+     * {@link FakeHealthSource}.
+     */
+    public void setFreshnessPolicy(LinkId id, FreshnessPolicy policy) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(policy, "policy");
+        policies.put(id, policy);
+        HealthSource source = sources.get(id);
+        if (source instanceof FakeHealthSource) {
+            ((FakeHealthSource) source).setPolicy(policy);
+        }
     }
 
     public void register(HealthSource source) {
         Objects.requireNonNull(source, "source");
         sources.put(source.id(), source);
+        if (source instanceof FakeHealthSource) {
+            FreshnessPolicy override = policies.get(source.id());
+            if (override != null) {
+                ((FakeHealthSource) source).setPolicy(override);
+            }
+        }
     }
 
     /**
@@ -40,7 +71,8 @@ public final class HealthRegistry {
         Objects.requireNonNull(report, "report");
         HealthSource source = sources.get(report.id());
         if (source == null) {
-            FakeHealthSource created = new FakeHealthSource(report.id(), report.domain());
+            FakeHealthSource created = new FakeHealthSource(
+                    report.id(), report.domain(), policyFor(report.id()));
             sources.put(report.id(), created);
             source = created;
         }
@@ -83,5 +115,10 @@ public final class HealthRegistry {
 
     public int size() {
         return sources.size();
+    }
+
+    private FreshnessPolicy policyFor(LinkId id) {
+        FreshnessPolicy override = policies.get(id);
+        return override != null ? override : defaultPolicy;
     }
 }

--- a/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
+++ b/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
@@ -27,22 +27,33 @@ class BeaconSessionTest {
 
     @Test
     void phase0StoresReportsWithoutLogging() {
-        FakeClock clock = new FakeClock();
+        FakeClock clock = new FakeClock(1L);
         BeaconSession session = new BeaconSession(BeaconFeatureFlags.defaults(), clock, 16);
         session.report(HealthReport.healthy(
-                LinkId.of("batteryTelemetry"), FailureDomain.ELECTRICAL, 0L, "AMPER"));
+                LinkId.of("batteryTelemetry"), FailureDomain.ELECTRICAL, 1L, "AMPER"));
         assertEquals(1, session.snapshot().size());
         assertEquals(0, session.logger().size());
         assertEquals(LinkState.HEALTHY, session.snapshot().get(0).state());
     }
 
     @Test
+    void timestampZeroIsUnknownNotHealthy() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.defaults(), clock, 16);
+        session.report(HealthReport.healthy(
+                LinkId.of("batteryTelemetry"), FailureDomain.ELECTRICAL, 0L, "AMPER"));
+        assertEquals(LinkState.UNKNOWN, session.snapshot().get(0).state());
+        assertEquals(0, session.logger().size());
+    }
+
+    @Test
     void phase1LogsManualReports() {
-        FakeClock clock = new FakeClock();
+        FakeClock clock = new FakeClock(1L);
         BeaconSession session = new BeaconSession(BeaconFeatureFlags.manualReports(), clock, 16);
         session.report(HealthReport.healthy(
-                LinkId.of("localization"), FailureDomain.SOFTWARE_LOOP, 0L, "Pedro"));
+                LinkId.of("localization"), FailureDomain.SOFTWARE_LOOP, 1L, "Pedro"));
         assertEquals(1, session.logger().size());
+        assertEquals(LinkState.HEALTHY, session.snapshot().get(0).state());
     }
 
     @Test

--- a/src/test/java/org/allsparks/beacon/api/LinkHealthTest.java
+++ b/src/test/java/org/allsparks/beacon/api/LinkHealthTest.java
@@ -41,6 +41,24 @@ class LinkHealthTest {
     }
 
     @Test
+    void toBuilderCopiesLatencyAndCounts() {
+        LinkHealth original = LinkHealth.builder(LinkId.of("expansionHub"))
+                .domain(FailureDomain.CONTROL_HUB_TO_EXPANSION_HUB)
+                .state(LinkState.HEALTHY)
+                .reason(LinkFailureReason.NONE)
+                .confidence(Confidence.of(0.9))
+                .observedLatencyMs(4.5)
+                .consecutiveSuccesses(3)
+                .lastValidTimestampNanos(100L)
+                .build();
+        LinkHealth copy = original.toBuilder().state(LinkState.STALE).reason(LinkFailureReason.STALE_DATA).build();
+        assertEquals(OptionalDouble.of(4.5), copy.observedLatencyMs());
+        assertEquals(3, copy.consecutiveSuccesses());
+        assertEquals(100L, copy.lastValidTimestampNanos());
+        assertEquals(LinkState.STALE, copy.state());
+    }
+
+    @Test
     void confidenceUnknownIsNotZero() {
         Confidence unknown = Confidence.unknown();
         assertFalse(unknown.isKnown());

--- a/src/test/java/org/allsparks/beacon/health/FreshnessPolicyTest.java
+++ b/src/test/java/org/allsparks/beacon/health/FreshnessPolicyTest.java
@@ -28,6 +28,14 @@ class FreshnessPolicyTest {
     }
 
     @Test
+    void manualReportsDefaultMatchesSimulationWindows() {
+        FreshnessPolicy defaults = FreshnessPolicy.manualReportsDefault();
+        assertEquals(40_000_000L, defaults.delayedThresholdNanos());
+        assertEquals(80_000_000L, defaults.staleThresholdNanos());
+        assertEquals(250_000_000L, defaults.lostThresholdNanos());
+    }
+
+    @Test
     void futureTimestampIsUnknownNotHealthy() {
         assertEquals(Freshness.UNKNOWN, policy.classify(50L, 10L));
     }

--- a/src/test/java/org/allsparks/beacon/health/HealthRegistryFreshnessTest.java
+++ b/src/test/java/org/allsparks/beacon/health/HealthRegistryFreshnessTest.java
@@ -1,0 +1,156 @@
+package org.allsparks.beacon.health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.allsparks.beacon.BeaconFeatureFlags;
+import org.allsparks.beacon.BeaconSession;
+import org.allsparks.beacon.api.Confidence;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.HealthReport;
+import org.allsparks.beacon.api.LinkFailureReason;
+import org.allsparks.beacon.api.LinkHealth;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.clock.FakeClock;
+import org.junit.jupiter.api.Test;
+
+class HealthRegistryFreshnessTest {
+    private static final LinkId CAMERA = LinkId.of("frontCamera");
+    private static final LinkId HUB = LinkId.of("expansionHub");
+
+    @Test
+    void freshHealthyReportIsHealthy() {
+        FakeClock clock = new FakeClock(1_000_000L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        LinkHealth health = registry.report(HealthReport.healthy(
+                CAMERA, FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
+        assertEquals(LinkState.HEALTHY, health.state());
+        assertEquals(1, health.consecutiveSuccesses());
+        assertEquals(0, health.consecutiveFailures());
+        assertFalse(BeaconSession.create().isInterventionEnabled());
+        assertFalse(BeaconFeatureFlags.defaults().isAnyInterventionEnabled());
+    }
+
+    @Test
+    void delayedWindowStillMapsToHealthy() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(50);
+        assertEquals(LinkState.HEALTHY, registry.snapshot().get(0).state());
+    }
+
+    @Test
+    void agePastStaleThresholdWithoutNewReport() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(81);
+        LinkHealth health = registry.snapshot().get(0);
+        assertEquals(LinkState.STALE, health.state());
+        assertEquals(LinkFailureReason.STALE_DATA, health.reason());
+        assertEquals(1, health.consecutiveSuccesses());
+        assertEquals(0, health.consecutiveFailures());
+    }
+
+    @Test
+    void agePastLostThresholdWithoutNewReport() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(251);
+        LinkHealth health = registry.snapshot().get(0);
+        assertEquals(LinkState.LOST, health.state());
+        assertEquals(LinkFailureReason.TIMEOUT, health.reason());
+        assertEquals(1, health.consecutiveSuccesses());
+        assertEquals(0, health.consecutiveFailures());
+    }
+
+    @Test
+    void explicitLossRemainsLostInsideCurrentWindow() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        registry.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                2L,
+                "ViDAR",
+                "pipeline stopped",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.8)));
+        clock.advanceMillis(10);
+        LinkHealth health = registry.snapshot().get(0);
+        assertEquals(LinkState.LOST, health.state());
+        assertEquals(LinkFailureReason.EXPLICIT_LOSS_REPORT, health.reason());
+        assertEquals(1L, health.lastValidTimestampNanos());
+    }
+
+    @Test
+    void consecutiveCountsAccumulateOnAcceptOnly() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(1);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
+        assertEquals(2, registry.snapshot().get(0).consecutiveSuccesses());
+
+        registry.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.STALE,
+                clock.nanoTime(),
+                "ViDAR",
+                "old frame",
+                LinkFailureReason.STALE_DATA,
+                Confidence.of(0.5)));
+        LinkHealth afterFailure = registry.snapshot().get(0);
+        assertEquals(0, afterFailure.consecutiveSuccesses());
+        assertEquals(1, afterFailure.consecutiveFailures());
+
+        registry.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                clock.nanoTime(),
+                "ViDAR",
+                "no frames",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.9)));
+        assertEquals(2, registry.snapshot().get(0).consecutiveFailures());
+    }
+
+    @Test
+    void timestampZeroHealthyReportIsUnknown() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        LinkHealth health = registry.report(HealthReport.healthy(
+                CAMERA, FailureDomain.USB_CAMERA, 0L, "ViDAR"));
+        assertEquals(LinkState.UNKNOWN, health.state());
+        assertEquals(LinkFailureReason.NEVER_OBSERVED, health.reason());
+    }
+
+    @Test
+    void futureTimestampIsUnknown() {
+        FakeClock clock = new FakeClock(10L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        LinkHealth health = registry.report(HealthReport.healthy(
+                CAMERA, FailureDomain.USB_CAMERA, 50L, "ViDAR"));
+        assertEquals(LinkState.UNKNOWN, health.state());
+        assertEquals(LinkFailureReason.INSUFFICIENT_EVIDENCE, health.reason());
+    }
+
+    @Test
+    void perSourcePolicyOverrideDoesNotChangeOthers() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.setFreshnessPolicy(CAMERA, FreshnessPolicy.ofMillis(5, 10, 20));
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        registry.report(HealthReport.healthy(HUB, FailureDomain.CONTROL_HUB_TO_EXPANSION_HUB, 1L, "robot"));
+        clock.advanceMillis(15);
+        assertEquals(LinkState.STALE, registry.get(CAMERA).get().state());
+        assertEquals(LinkState.HEALTHY, registry.get(HUB).get().state());
+    }
+}

--- a/src/test/java/org/allsparks/beacon/health/HealthRegistryTest.java
+++ b/src/test/java/org/allsparks/beacon/health/HealthRegistryTest.java
@@ -37,6 +37,7 @@ class HealthRegistryTest {
                 org.allsparks.beacon.api.LinkFailureReason.EXPLICIT_LOSS_REPORT,
                 org.allsparks.beacon.api.Confidence.of(0.8)));
         assertEquals(LinkState.LOST, source.sample(10L).state());
+        assertEquals(org.allsparks.beacon.api.LinkFailureReason.EXPLICIT_LOSS_REPORT, source.sample(10L).reason());
         assertEquals(1, source.sample(10L).consecutiveFailures());
     }
 }


### PR DESCRIPTION
## Summary

Stored health reports now age. `HealthRegistry` snapshots apply `FreshnessPolicy` at sample time, consecutive counts accumulate across reports, and a timestamp of `0` is `UNKNOWN` rather than `HEALTHY`.

## Problem

A single `HEALTHY` report stayed `HEALTHY` forever because `FakeHealthSource.sample(nowNanos)` ignored time and never called `FreshnessPolicy`. Consecutive success/failure counts reset to 1 on every report.

## Solution

Overlay freshness when sampling the last observation. Explicit reporter `LOST` still wins. Aging does not change consecutive counts. Default policy is `40 / 80 / 250` ms for manual and test reports only.

## Scope

- `FakeHealthSource`, `HealthRegistry`, `FreshnessPolicy.manualReportsDefault()`, `LinkHealth.toBuilder()`
- Unit tests for delayed/stale/lost windows, explicit loss, consecutive counts, timestamp `0`, future timestamps, per-source override
- Examples, architecture, changelog, phase status

## Out of scope

- Control Hub overhead (#10)
- Preflight inspector (#15)
- Automatic event transitions (#16)
- Actuators, recovery, Driver Station safe-stop
- `LinkState` delayed/recovering values

## Architecture impact

Sampling is the freshness seam. `DELAYED` still maps to `LinkState.HEALTHY`. No sibling-library compile-time dependencies.

## Safety impact

- Does **not** enable motor, servo, or network intervention by default
- Missing/stale observations fail safe (`UNKNOWN` / `STALE` / `LOST`)
- Does not use private SDK APIs
- No secrets

## Compatibility impact

Behavior change for callers that treated the last report as permanently healthy, or used timestamp `0` as healthy. Intended correction. No published non-snapshot release yet.

## Tests

- Added `HealthRegistryFreshnessTest`
- Updated `BeaconSessionTest`, `HealthRegistryTest`, `LinkHealthTest`, `FreshnessPolicyTest`

## Validation results

| Command | Result |
|---------|--------|
| `.\gradlew.bat check --no-daemon` | BUILD SUCCESSFUL |

## Hardware validation

None. Desktop unit tests with `FakeClock` only.

## Documentation

`architecture.md`, `examples/README.md`, `examples/passive-health-monitor/README.md`, `phases.md`, `testing.md`, `glossary.md`, `README.md`, `CHANGELOG.md`, `docs/audits/priority-ledger.md`

## Risks

Default thresholds are for manual/test reports, not cameras vs gamepads vs DS packets. Override per `LinkId`. Inclusive policy bounds: tests use strictly past stale/lost.

## Rollback or disable strategy

Set a source policy with a very large lost threshold to restore last-report-wins. Revert this PR if needed. Feature remains passive.

## Known limitations

- `DELAYED` is not a visible `LinkState`
- Control Hub overhead still unmeasured
- Not robot-validated

## Related issue

Closes #30. Part of #29.

## Phase / maturity impact

- [x] Phase 1 manual health reports
- [ ] Phase 2+ (requires explicit safety review)

## Safety

- [x] Does **not** enable motor, servo, or network intervention by default
- [x] Missing/stale observations fail safe
- [x] Does not use private SDK APIs in competition code
- [x] No secrets or private team data included

## Validation evidence

- [x] `./gradlew check` (or `gradlew.bat check`) passed locally
- [x] Unit tests added/updated
- [x] Hardware validation status: desktop

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
