### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: "17"
@@ -29,7 +29,7 @@ jobs:
   docs-structure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Required documentation present
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 - Stored health snapshots now apply `FreshnessPolicy` at sample time. A timestamp of `0` is `UNKNOWN`, not `HEALTHY`. Consecutive success/failure counts accumulate across reports.
 
+### Security
+
+- CI GitHub Actions (`actions/checkout`, `actions/setup-java`) are pinned to full commit SHAs with version comments.
+
 ### Safety
 
 - All motor, servo, hardware-recovery, and network-intervention features remain disabled by default.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ cd BEACON
 - Update docs when behavior or maturity labels change.
 - Run `.\gradlew.bat test` (or `./gradlew test`) before requesting review.
 
+GitHub Actions in `.github/workflows/` are pinned to full commit SHAs with a version comment (for example `# v4.4.0`). Dependabot can still propose updates to those pins.
+
 ## Line endings
 
 The repository stores LF line endings (see [.gitattributes](.gitattributes)).

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -2,11 +2,11 @@
 
 Living tracker for orchestrator selection. Update after each merged PR or when issue readiness changes.
 
-**Last updated:** 2026-08-17  
-**Audited commit:** `56a85b5` (`main` after PR #28)  
-**Automatic merge:** false (human approval required)  
+**Last updated:** 2026-08-18  
+**Audited commit:** `a2230ae` (`main` after PR #37)  
+**Automatic merge:** false except when the user explicitly says to proceed on a ready PR  
 **Max active implementation subagents:** 1  
-**Open implementation PR:** issue #30 on `phase-1/30-freshness-sampling`
+**Open implementation PR:** issue #31 on `repo/31-pin-actions-shas`
 
 ## Priority model
 
@@ -30,22 +30,23 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 ## Current selection
 
-PR #28 is merged. Current implementation: [#30](https://github.com/The-Allsparks/BEACON/issues/30) freshness-aware sampling.
+PR #37 is merged (`Closes #30`). Current implementation: [#31](https://github.com/The-Allsparks/BEACON/issues/31) pin GitHub Actions to SHAs.
 
 | Issue | Priority | Readiness | Dependencies | Current status | Assigned subagent | Branch | Pull request | CI status | Merge status | Blocker | Next action |
 |-------|----------|-----------|--------------|----------------|-------------------|--------|--------------|-----------|--------------|---------|-------------|
-| [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | done | merged | none | Merged to `main` | — | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | success | merged | none | Close #6–#9 |
-| [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | 1 | Ready | #9, #10 software | Implementing | orchestrator | `phase-1/30-freshness-sampling` | pending | pending | — | none | Test, open PR, wait for CI |
+| [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | done | merged | none | Merged | — | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | success | merged | none | done |
+| [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | done | merged | #9, #10 software | Merged | — | `phase-1/30-freshness-sampling` | [#37](https://github.com/The-Allsparks/BEACON/pull/37) | success | merged | none | done |
+| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | 1 | Ready | none | Implementing | orchestrator | `repo/31-pin-actions-shas` | pending | pending | — | none | Open PR; wait for CI |
 | [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 2 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
-| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | 3 | Ready after #30 PR resolves | none | Open | — | — | — | — | — | Open #30 PR | Follow-up PR |
+| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 3 | Ready after #30 | #30 | Open | — | — | — | — | — | none | Next product slice after #31 |
 | [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 4 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
 | [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 5 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
-| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 6 | Not ready | #30 | Open | — | — | — | — | — | Time-honest registry | After #30 merges |
-| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 7 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
-| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 8 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
-| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 9 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
-| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 10 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
+| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 6 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
+| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 7 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
+| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 8 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
+| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 9 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
 | [#29](https://github.com/The-Allsparks/BEACON/issues/29) Roadmap epic | tracking | n/a | none | Open | orchestrator | n/a | n/a | n/a | n/a | none | Update after each merge |
+| Dependabot #33–#36 | deferred | not selected | compatibility analysis | Open PRs | — | dependabot/* | [#33](https://github.com/The-Allsparks/BEACON/pull/33)–[#36](https://github.com/The-Allsparks/BEACON/pull/36) | unknown | — | Major Gradle/JUnit/Actions upgrades | Do not merge without analysis |
 
 ## Phase 0 issue hygiene (software vs remaining AC)
 
@@ -66,7 +67,7 @@ Implemented in PR #28 tree; close **after merge** if remaining ACs are explicitl
 
 ## Stop conditions currently in effect
 
-- Do not merge without human approval.
+- Do not merge without human approval, unless the user explicitly says to proceed on a ready PR.
 - Do not implement Phase 5–9 active behavior.
 - Do not claim hardware validation.
 - One implementation PR at a time.


### PR DESCRIPTION
## Summary

Pin CI GitHub Actions to full commit SHAs with version comments so moving major tags cannot silently change the workflow.

## Problem

`.github/workflows/ci.yml` used `actions/checkout@v4` and `actions/setup-java@v4`. Those tags can move.

## Solution

Pin the current v4 lines:

- `actions/checkout@11d5960a326750d5838078e36cf38b85af677262` # v4.4.0
- `actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3` # v4.9.1

Dependabot already watches GitHub Actions monthly and can update SHA pins when version comments are present.

## Scope

- SHA pins in `.github/workflows/ci.yml`
- Note in `CONTRIBUTING.md`
- Changelog and priority ledger

## Out of scope

- Major upgrades (`checkout` v7, `setup-java` v5, Gradle 9, JUnit 6). Those are Dependabot PRs #33–#36 and need separate compatibility analysis. `setup-java` v4 is deprecated upstream; migrating to v5 is a follow-up, not this issue.
- Branch protection (#32)
- Preflight inspector (#15)

## Architecture impact

None. Repository CI only.

## Safety impact

- Does **not** enable motor, servo, or network intervention
- Improves CI supply-chain integrity
- No robot behavior change

## Compatibility impact

Same Actions major versions the workflow already used (`v4`). Java 17 Temurin and `./gradlew check` unchanged.

## Tests

No application tests changed. Validation is this PR’s GitHub Actions run.

## Validation results

| Command | Result |
|---------|--------|
| Local `gradlew check` | hung on daemon fork this session; not used as evidence |
| GitHub Actions on this PR | required (Ubuntu, Windows, docs-structure) |

## Hardware validation

None. Desktop / CI only.

## Documentation

`CONTRIBUTING.md`, `CHANGELOG.md`, `docs/audits/priority-ledger.md`

## Risks

Wrong SHA for a tag. Pins were taken from `refs/tags/v4` / `v4.9.1` on the official Action repos at change time.

## Rollback or disable strategy

Revert this PR to restore moving `@v4` tags.

## Known limitations

Does not migrate `setup-java` off deprecated v4.

## Related issue

Closes #31. Part of #29.

## Phase / maturity impact

- [x] Documentation only (plus CI pin)
- [ ] Phase 0 vocabulary / immutable reports
- [ ] Phase 1 manual health reports
- [ ] Phase 2+ (requires explicit safety review)
- [ ] Research / citations

## Safety

- [x] Does **not** enable motor, servo, or network intervention by default
- [x] Missing/stale observations fail safe
- [x] Does not use private SDK APIs in competition code
- [x] No secrets or private team data included

## Validation evidence

- [ ] `./gradlew check` (or `gradlew.bat check`) passed locally
- [ ] Unit tests added/updated
- [x] Hardware validation status: none

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
