### PR TITLE
Add registry-backed preflight inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Source-backed communications-health research, Driver Station freshness feasibility study, architecture, phased roadmap, and student documentation.
 - Initial deep audit and priority ledger under `docs/audits/`.
 - CI for compile, unit tests, and relative documentation link checks.
+- Phase 2 `PreflightInspector`: required vs optional expectations against registry snapshots.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Repository: **[The-Allsparks/BEACON](https://github.com/The-Allsparks/BEACON)**
 | Item | Status |
 |------|--------|
 | **Version** | `0.1.0-SNAPSHOT` |
-| **Implemented phase** | **Phase 0** (vocabulary, immutable reports, fake clocks, manual registry, passive logging types) |
+| **Implemented phase** | **Phase 0–2 types** (vocabulary, aging registry, preflight inspector). Flags for Phase 1+ default off. |
 | **Phase 1** | Manual reports + time-correlated sampling (`FreshnessPolicy` overlay); flag default off; not hardware-validated |
-| **Phases 2–10** | Designed / experimental / **disabled by default** |
+| **Phase 2** | `PreflightInspector` against registry snapshots; flag default off; no hardware probing |
+| **Phases 3–10** | Designed / experimental / **disabled by default** |
 | **Active motor, servo, or network intervention** | **Disabled.** Do not enable without review and acceptance tests. |
 | **Driver Station early safe-stop** | **Not implemented.** No reliable supported public freshness API was verified. See [driver-link.md](docs/communications-health/driver-link.md). |
 | **Production safety claims** | **None.** This scaffold has not been validated on a real FTC robot. |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -3,10 +3,10 @@
 Living tracker for orchestrator selection. Update after each merged PR or when issue readiness changes.
 
 **Last updated:** 2026-08-18  
-**Audited commit:** `a2230ae` (`main` after PR #37)  
-**Automatic merge:** false except when the user explicitly says to proceed on a ready PR  
+**Audited commit:** `4bbe70f` (`main` after PR #38)  
+**Automatic merge:** false except when the user explicitly says to proceed or continue on a ready PR  
 **Max active implementation subagents:** 1  
-**Open implementation PR:** issue #31 on `repo/31-pin-actions-shas`
+**Open implementation PR:** issue #15 on `phase-2/15-preflight-inspector`
 
 ## Priority model
 
@@ -30,21 +30,21 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 ## Current selection
 
-PR #37 is merged (`Closes #30`). Current implementation: [#31](https://github.com/The-Allsparks/BEACON/issues/31) pin GitHub Actions to SHAs.
+PR #38 is merged (`Closes #31`). Current implementation: [#15](https://github.com/The-Allsparks/BEACON/issues/15) preflight inspector.
 
 | Issue | Priority | Readiness | Dependencies | Current status | Assigned subagent | Branch | Pull request | CI status | Merge status | Blocker | Next action |
 |-------|----------|-----------|--------------|----------------|-------------------|--------|--------------|-----------|--------------|---------|-------------|
 | [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | done | merged | none | Merged | — | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | success | merged | none | done |
 | [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | done | merged | #9, #10 software | Merged | — | `phase-1/30-freshness-sampling` | [#37](https://github.com/The-Allsparks/BEACON/pull/37) | success | merged | none | done |
-| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | 1 | Ready | none | Implementing | orchestrator | `repo/31-pin-actions-shas` | pending | pending | — | none | Open PR; wait for CI |
+| [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | done | merged | none | Merged | — | `repo/31-pin-actions-shas` | [#38](https://github.com/The-Allsparks/BEACON/pull/38) | success | merged | none | done |
+| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 1 | Ready | #30 | Implementing | orchestrator | `phase-2/15-preflight-inspector` | pending | pending | — | none | Test, open PR |
 | [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 2 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
-| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 3 | Ready after #30 | #30 | Open | — | — | — | — | — | none | Next product slice after #31 |
-| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 4 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
-| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 5 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
-| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 6 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
-| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 7 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
-| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 8 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
-| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 9 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
+| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 3 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
+| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 4 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
+| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 5 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
+| [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 6 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
+| [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 7 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
+| [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 8 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
 | [#29](https://github.com/The-Allsparks/BEACON/issues/29) Roadmap epic | tracking | n/a | none | Open | orchestrator | n/a | n/a | n/a | n/a | none | Update after each merge |
 | Dependabot #33–#36 | deferred | not selected | compatibility analysis | Open PRs | — | dependabot/* | [#33](https://github.com/The-Allsparks/BEACON/pull/33)–[#36](https://github.com/The-Allsparks/BEACON/pull/36) | unknown | — | Major Gradle/JUnit/Actions upgrades | Do not merge without analysis |
 

--- a/docs/communications-health/architecture.md
+++ b/docs/communications-health/architecture.md
@@ -52,7 +52,7 @@ Do not invent latency when overlaying.
 
 ## PreflightInspector
 
-Designed for Phase 2. Types exist (`PreflightStatus`, `PreflightFinding`). Every finding must explain why. Results: `READY`, `READY_DEGRADED`, `NOT_READY`, `UNKNOWN`. The inspector must not command actuators.
+Phase 2. `PreflightInspector.evaluate(registry, expectations)` classifies declared required/optional links from existing `LinkHealth` snapshots. Every finding explains why. Results: `READY`, `READY_DEGRADED`, `NOT_READY`, `UNKNOWN`. The inspector must not command actuators, probe devices, or invent a Driver Station heartbeat. `BeaconSession.preflight` is off unless the Phase 2 flag is enabled.
 
 ## EventCorrelator
 

--- a/docs/communications-health/phases.md
+++ b/docs/communications-health/phases.md
@@ -30,6 +30,8 @@ Report required/optional Hubs, cameras, sensors, gamepads where observable, AMPE
 
 **Acceptance:** every failure explains why; optional failures yield `READY_DEGRADED`; checklist does not command actuators; false positives tested.
 
+**Status:** inspector implemented against the health registry; flag default off; no hardware probing.
+
 ## Phase 3 — Passive event history
 
 **Teach:** What happened immediately before the failure?

--- a/docs/communications-health/preflight.md
+++ b/docs/communications-health/preflight.md
@@ -1,6 +1,6 @@
 # Preflight
 
-Phase 2. Types exist; the inspector is not enabled.
+Phase 2. `PreflightInspector` evaluates **declared** expected links against the health registry. It does not probe hardware or command actuators. `BeaconSession.preflight` is disabled unless `BeaconFeatureFlags.preflight()` (or `phase2Preflight(true)`) is set.
 
 ## Purpose
 
@@ -12,12 +12,24 @@ Find problems **before** the match. The checklist must not command actuators.
 |--------|---------|
 | `READY` | All required items have explanations that support go |
 | `READY_DEGRADED` | Optional item failed or is absent; robot may play with documented limits |
-| `NOT_READY` | A required item failed |
+| `NOT_READY` | A required item failed (`STALE` or `LOST`) |
 | `UNKNOWN` | Evidence missing; fail closed for required items |
 
 Every finding must include a non-empty explanation.
 
+## Evaluation rules
+
+- Teams pass a list of `PreflightExpectation.required` / `optional` link ids. BEACON does not invent a robot-wide default checklist.
+- Optional absence → `READY_DEGRADED`.
+- Required link with **no report** → `UNKNOWN`, not a fabricated Driver Station `NOT_READY`.
+- Required `STALE` or `LOST` → `NOT_READY`.
+- Overall status is the worst finding: `NOT_READY` > `UNKNOWN` > `READY_DEGRADED` > `READY`.
+- An empty expectation list fails closed (`UNKNOWN`).
+- When the Phase 2 flag is off, `BeaconSession.preflight` returns `UNKNOWN` and does not log a ready call.
+
 ## Suggested checklist
+
+Declare these as expectations, then have sibling libraries or robot code `report(...)` them:
 
 - Required Hubs present
 - Optional Hubs present or absent (absence is degraded, not blocking)

--- a/docs/communications-health/testing.md
+++ b/docs/communications-health/testing.md
@@ -2,7 +2,7 @@
 
 ## Unit tests (Phase 0, implemented)
 
-Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`.
+Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`, preflight required vs optional (optional absence `READY_DEGRADED`, required missing evidence `UNKNOWN`, required `LOST`/`STALE` `NOT_READY`).
 
 ## Simulation tests (Phase 0, partial)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,20 @@ Use a positive source timestamp. `0` means never observed and snapshots as `UNKN
 
 BEACON only stores, ages, and logs. It does not probe or restart devices.
 
+## Phase 2 — preflight
+
+```java
+BeaconSession beacon = BeaconSession.create(BeaconFeatureFlags.preflight());
+beacon.report(HealthReport.healthy(
+        LinkId.of("frontCamera"), FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
+PreflightReport preflight = beacon.preflight(Arrays.asList(
+        PreflightExpectation.required(LinkId.of("frontCamera")),
+        PreflightExpectation.optional(LinkId.of("expansionHub"))));
+// Optional Expansion Hub with no report → READY_DEGRADED, not NOT_READY.
+```
+
+The inspector does not command actuators and does not invent a Driver Station heartbeat. A required link with no report is `UNKNOWN`.
+
 ## Later phases
 
 Do not enable from examples until acceptance tests in [phases.md](../docs/communications-health/phases.md) pass and maintainers review. Driver Station safe-stop remains research-only until a supported freshness source is proven.

--- a/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
+++ b/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
@@ -172,4 +172,9 @@ public final class BeaconFeatureFlags {
     public static BeaconFeatureFlags manualReports() {
         return builder().phase1ManualReports(true).build();
     }
+
+    /** Phase 0–2: manual reports and preflight. No output intervention. */
+    public static BeaconFeatureFlags preflight() {
+        return builder().phase1ManualReports(true).phase2Preflight(true).build();
+    }
 }

--- a/src/main/java/org/allsparks/beacon/BeaconSession.java
+++ b/src/main/java/org/allsparks/beacon/BeaconSession.java
@@ -12,6 +12,11 @@ import org.allsparks.beacon.health.HealthRegistry;
 import org.allsparks.beacon.log.BeaconEvent;
 import org.allsparks.beacon.log.BeaconEventLogger;
 import org.allsparks.beacon.log.BeaconEventType;
+import org.allsparks.beacon.preflight.PreflightExpectation;
+import org.allsparks.beacon.preflight.PreflightFinding;
+import org.allsparks.beacon.preflight.PreflightInspector;
+import org.allsparks.beacon.preflight.PreflightReport;
+import org.allsparks.beacon.preflight.PreflightStatus;
 
 /**
  * Per-OpMode BEACON session. Observes and logs; never commands motors, servos,
@@ -106,5 +111,30 @@ public final class BeaconSession {
             return registry.get(id).get().domain();
         }
         return FailureDomain.UNKNOWN;
+    }
+
+    /**
+     * Evaluate declared expected links. Does not command actuators. When Phase 2
+     * is disabled, the result is {@link PreflightStatus#UNKNOWN} rather than a
+     * fabricated ready or not-ready call.
+     */
+    public PreflightReport preflight(List<PreflightExpectation> expected) {
+        Objects.requireNonNull(expected, "expected");
+        if (!flags.isPhase2Preflight()) {
+            PreflightFinding finding = new PreflightFinding(
+                    LinkId.of("preflight"),
+                    true,
+                    PreflightStatus.UNKNOWN,
+                    "Phase 2 preflight is disabled by feature flags.");
+            return PreflightReport.of(PreflightStatus.UNKNOWN, java.util.Collections.singletonList(finding));
+        }
+        PreflightReport report = PreflightInspector.evaluate(registry, expected);
+        logger.record(new BeaconEvent(
+                clock.nanoTime(),
+                BeaconEventType.PREFLIGHT,
+                LinkId.of("preflight"),
+                FailureDomain.SOFTWARE_LOOP,
+                report.status().name()));
+        return report;
     }
 }

--- a/src/main/java/org/allsparks/beacon/preflight/PreflightExpectation.java
+++ b/src/main/java/org/allsparks/beacon/preflight/PreflightExpectation.java
@@ -1,0 +1,31 @@
+package org.allsparks.beacon.preflight;
+
+import java.util.Objects;
+import org.allsparks.beacon.api.LinkId;
+
+/** One expected link on the pre-match checklist. */
+public final class PreflightExpectation {
+    private final LinkId id;
+    private final boolean required;
+
+    public PreflightExpectation(LinkId id, boolean required) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.required = required;
+    }
+
+    public static PreflightExpectation required(LinkId id) {
+        return new PreflightExpectation(id, true);
+    }
+
+    public static PreflightExpectation optional(LinkId id) {
+        return new PreflightExpectation(id, false);
+    }
+
+    public LinkId id() {
+        return id;
+    }
+
+    public boolean required() {
+        return required;
+    }
+}

--- a/src/main/java/org/allsparks/beacon/preflight/PreflightInspector.java
+++ b/src/main/java/org/allsparks/beacon/preflight/PreflightInspector.java
@@ -1,0 +1,138 @@
+package org.allsparks.beacon.preflight;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.allsparks.beacon.api.LinkHealth;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.health.HealthRegistry;
+
+/**
+ * Evaluates declared expected links against the health registry. Does not probe
+ * devices, invent Driver Station heartbeats, or command actuators.
+ */
+public final class PreflightInspector {
+    private static final LinkId PREFLIGHT_ID = LinkId.of("preflight");
+
+    private PreflightInspector() {}
+
+    public static PreflightReport evaluate(HealthRegistry registry, List<PreflightExpectation> expected) {
+        Objects.requireNonNull(registry, "registry");
+        Objects.requireNonNull(expected, "expected");
+        if (expected.isEmpty()) {
+            PreflightFinding finding = new PreflightFinding(
+                    PREFLIGHT_ID,
+                    true,
+                    PreflightStatus.UNKNOWN,
+                    "Preflight was requested with no expected links. Declare required and optional links before a match.");
+            return PreflightReport.of(PreflightStatus.UNKNOWN, Collections.singletonList(finding));
+        }
+        List<PreflightFinding> findings = new ArrayList<>(expected.size());
+        PreflightStatus worst = PreflightStatus.READY;
+        for (PreflightExpectation expectation : expected) {
+            Objects.requireNonNull(expectation, "expectation");
+            PreflightFinding finding = evaluateOne(registry, expectation);
+            findings.add(finding);
+            worst = worse(worst, finding.status());
+        }
+        return PreflightReport.of(worst, findings);
+    }
+
+    private static PreflightFinding evaluateOne(HealthRegistry registry, PreflightExpectation expectation) {
+        Optional<LinkHealth> observed = registry.get(expectation.id());
+        if (!observed.isPresent()) {
+            if (expectation.required()) {
+                return new PreflightFinding(
+                        expectation.id(),
+                        true,
+                        PreflightStatus.UNKNOWN,
+                        "No health report for required link "
+                                + expectation.id()
+                                + ". Evidence is missing; this is not treated as a Driver Station network failure.");
+            }
+            return new PreflightFinding(
+                    expectation.id(),
+                    false,
+                    PreflightStatus.READY_DEGRADED,
+                    "Optional link " + expectation.id() + " has no health report.");
+        }
+        LinkHealth health = observed.get();
+        LinkState state = health.state();
+        if (state == LinkState.HEALTHY) {
+            return new PreflightFinding(
+                    expectation.id(),
+                    expectation.required(),
+                    PreflightStatus.READY,
+                    "Link " + expectation.id() + " is healthy.");
+        }
+        if (state == LinkState.STALE) {
+            if (expectation.required()) {
+                return new PreflightFinding(
+                        expectation.id(),
+                        true,
+                        PreflightStatus.NOT_READY,
+                        "Required link "
+                                + expectation.id()
+                                + " is stale ("
+                                + health.reason()
+                                + ").");
+            }
+            return new PreflightFinding(
+                    expectation.id(),
+                    false,
+                    PreflightStatus.READY_DEGRADED,
+                    "Optional link " + expectation.id() + " is stale (" + health.reason() + ").");
+        }
+        if (state == LinkState.LOST) {
+            if (expectation.required()) {
+                return new PreflightFinding(
+                        expectation.id(),
+                        true,
+                        PreflightStatus.NOT_READY,
+                        "Required link " + expectation.id() + " is lost (" + health.reason() + ").");
+            }
+            return new PreflightFinding(
+                    expectation.id(),
+                    false,
+                    PreflightStatus.READY_DEGRADED,
+                    "Optional link " + expectation.id() + " is lost (" + health.reason() + ").");
+        }
+        if (expectation.required()) {
+            return new PreflightFinding(
+                    expectation.id(),
+                    true,
+                    PreflightStatus.UNKNOWN,
+                    "Required link "
+                            + expectation.id()
+                            + " has unknown health ("
+                            + health.reason()
+                            + ").");
+        }
+        return new PreflightFinding(
+                expectation.id(),
+                false,
+                PreflightStatus.READY_DEGRADED,
+                "Optional link " + expectation.id() + " has unknown health (" + health.reason() + ").");
+    }
+
+    static PreflightStatus worse(PreflightStatus left, PreflightStatus right) {
+        return rank(left) >= rank(right) ? left : right;
+    }
+
+    private static int rank(PreflightStatus status) {
+        switch (status) {
+            case NOT_READY:
+                return 3;
+            case UNKNOWN:
+                return 2;
+            case READY_DEGRADED:
+                return 1;
+            case READY:
+            default:
+                return 0;
+        }
+    }
+}

--- a/src/main/java/org/allsparks/beacon/preflight/PreflightReport.java
+++ b/src/main/java/org/allsparks/beacon/preflight/PreflightReport.java
@@ -1,0 +1,36 @@
+package org.allsparks.beacon.preflight;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Aggregate preflight result. Does not command actuators. */
+public final class PreflightReport {
+    private final PreflightStatus status;
+    private final List<PreflightFinding> findings;
+
+    public PreflightReport(PreflightStatus status, List<PreflightFinding> findings) {
+        this.status = Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(findings, "findings");
+        this.findings = Collections.unmodifiableList(new ArrayList<>(findings));
+        if (this.findings.isEmpty() && status != PreflightStatus.READY) {
+            throw new IllegalArgumentException("Non-ready preflight reports must include findings");
+        }
+        for (PreflightFinding finding : this.findings) {
+            Objects.requireNonNull(finding, "finding");
+        }
+    }
+
+    public static PreflightReport of(PreflightStatus status, List<PreflightFinding> findings) {
+        return new PreflightReport(status, findings);
+    }
+
+    public PreflightStatus status() {
+        return status;
+    }
+
+    public List<PreflightFinding> findings() {
+        return findings;
+    }
+}

--- a/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
+++ b/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
 import org.allsparks.beacon.adapters.future.SystemCoreAdapterBoundary;
 import org.allsparks.beacon.api.FailureDomain;
 import org.allsparks.beacon.api.HealthReport;
 import org.allsparks.beacon.api.LinkId;
 import org.allsparks.beacon.api.LinkState;
 import org.allsparks.beacon.clock.FakeClock;
+import org.allsparks.beacon.preflight.PreflightExpectation;
 import org.allsparks.beacon.preflight.PreflightFinding;
 import org.allsparks.beacon.preflight.PreflightStatus;
 import org.allsparks.beacon.recovery.RecoveryPolicy;
@@ -73,5 +76,34 @@ class BeaconSessionTest {
                 PreflightStatus.READY_DEGRADED,
                 "Optional Expansion Hub is absent");
         assertEquals(PreflightStatus.READY_DEGRADED, finding.status());
+    }
+
+    @Test
+    void preflightDisabledFailsUnknown() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.defaults(), clock, 16);
+        assertEquals(
+                PreflightStatus.UNKNOWN,
+                session.preflight(Collections.singletonList(PreflightExpectation.required(LinkId.of("frontCamera"))))
+                        .status());
+        assertEquals(0, session.logger().size());
+        assertFalse(session.isInterventionEnabled());
+    }
+
+    @Test
+    void preflightEnabledLogsAndDoesNotCommand() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.preflight(), clock, 16);
+        session.report(HealthReport.healthy(
+                LinkId.of("frontCamera"), FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        assertEquals(
+                PreflightStatus.READY_DEGRADED,
+                session.preflight(Arrays.asList(
+                                PreflightExpectation.required(LinkId.of("frontCamera")),
+                                PreflightExpectation.optional(LinkId.of("expansionHub"))))
+                        .status());
+        assertTrue(session.logger().size() >= 1);
+        assertFalse(session.isInterventionEnabled());
+        assertFalse(session.flags().isPhase5DrivetrainSafeStop());
     }
 }

--- a/src/test/java/org/allsparks/beacon/preflight/PreflightInspectorTest.java
+++ b/src/test/java/org/allsparks/beacon/preflight/PreflightInspectorTest.java
@@ -1,0 +1,106 @@
+package org.allsparks.beacon.preflight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.HealthReport;
+import org.allsparks.beacon.api.LinkFailureReason;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.clock.FakeClock;
+import org.allsparks.beacon.health.HealthRegistry;
+import org.junit.jupiter.api.Test;
+
+class PreflightInspectorTest {
+    private static final LinkId CAMERA = LinkId.of("frontCamera");
+    private static final LinkId HUB = LinkId.of("expansionHub");
+    private static final LinkId LOCALIZATION = LinkId.of("localization");
+
+    @Test
+    void allRequiredHealthyIsReady() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        registry.report(HealthReport.healthy(LOCALIZATION, FailureDomain.SOFTWARE_LOOP, 1L, "Pedro"));
+        PreflightReport report = PreflightInspector.evaluate(
+                registry,
+                Arrays.asList(PreflightExpectation.required(CAMERA), PreflightExpectation.required(LOCALIZATION)));
+        assertEquals(PreflightStatus.READY, report.status());
+        assertEquals(2, report.findings().size());
+        assertFalse(report.findings().get(0).explanation().trim().isEmpty());
+    }
+
+    @Test
+    void optionalAbsenceIsReadyDegraded() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        PreflightReport report = PreflightInspector.evaluate(
+                registry,
+                Arrays.asList(PreflightExpectation.required(CAMERA), PreflightExpectation.optional(HUB)));
+        assertEquals(PreflightStatus.READY_DEGRADED, report.status());
+        assertEquals(PreflightStatus.READY_DEGRADED, report.findings().get(1).status());
+        assertTrue(report.findings().get(1).explanation().contains("expansionHub"));
+    }
+
+    @Test
+    void requiredLostIsNotReady() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                1L,
+                "ViDAR",
+                "no frames",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                org.allsparks.beacon.api.Confidence.of(0.9)));
+        PreflightReport report = PreflightInspector.evaluate(
+                registry, Collections.singletonList(PreflightExpectation.required(CAMERA)));
+        assertEquals(PreflightStatus.NOT_READY, report.status());
+        assertTrue(report.findings().get(0).explanation().contains("lost"));
+    }
+
+    @Test
+    void requiredMissingEvidenceIsUnknownNotFabricatedNetworkFailure() {
+        HealthRegistry registry = new HealthRegistry(new FakeClock(1L));
+        PreflightReport report = PreflightInspector.evaluate(
+                registry,
+                Collections.singletonList(
+                        PreflightExpectation.required(LinkId.of("driverStation"))));
+        assertEquals(PreflightStatus.UNKNOWN, report.status());
+        assertTrue(report.findings().get(0).explanation().contains("not treated as a Driver Station network failure"));
+    }
+
+    @Test
+    void requiredStaleIsNotReady() {
+        FakeClock clock = new FakeClock(1L);
+        HealthRegistry registry = new HealthRegistry(clock);
+        registry.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(81);
+        PreflightReport report = PreflightInspector.evaluate(
+                registry, Collections.singletonList(PreflightExpectation.required(CAMERA)));
+        assertEquals(PreflightStatus.NOT_READY, report.status());
+        assertTrue(report.findings().get(0).explanation().contains("stale"));
+    }
+
+    @Test
+    void emptyExpectationsFailClosed() {
+        HealthRegistry registry = new HealthRegistry(new FakeClock(1L));
+        PreflightReport report = PreflightInspector.evaluate(registry, Collections.emptyList());
+        assertEquals(PreflightStatus.UNKNOWN, report.status());
+        assertFalse(report.findings().get(0).explanation().trim().isEmpty());
+    }
+
+    @Test
+    void notReadyOutranksUnknownAndDegraded() {
+        assertEquals(PreflightStatus.NOT_READY, PreflightInspector.worse(PreflightStatus.UNKNOWN, PreflightStatus.NOT_READY));
+        assertEquals(PreflightStatus.UNKNOWN, PreflightInspector.worse(PreflightStatus.READY_DEGRADED, PreflightStatus.UNKNOWN));
+        assertEquals(PreflightStatus.READY_DEGRADED, PreflightInspector.worse(PreflightStatus.READY, PreflightStatus.READY_DEGRADED));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 preflight inspects **declared** required and optional links against the health registry. It does not probe devices, command actuators, or invent a Driver Station heartbeat.

## Problem

Teams needed a match-readiness check with precise meanings for missing optional hardware vs missing evidence vs a real required failure.

## Solution

- `PreflightInspector.evaluate(registry, expectations)`
- Optional absence → `READY_DEGRADED`
- Required missing report → `UNKNOWN` (fail closed, not a fabricated network `NOT_READY`)
- Required `STALE`/`LOST` → `NOT_READY`
- `BeaconSession.preflight` is off unless `BeaconFeatureFlags.preflight()` enables Phase 2
- Empty expectation lists fail closed

## Scope

- Inspector, expectation/report types, session entry point, unit tests, docs/examples

## Out of scope

- Hardware probing (Lynx, cameras, gamepads)
- Sibling DTO adapters (#11–#14)
- Phase 3 automatic event history (#16)
- Actuators or Driver Station safe-stop

## Architecture impact

Preflight is a pure evaluation of existing snapshots. Loop order still stops before actuator writes.

## Safety impact

- Does **not** enable motor, servo, or network intervention
- Missing/stale observations fail safe
- Disabled flag cannot report `READY`

## Compatibility impact

New APIs only. Phase 2 remains off by default.

## Tests

- `PreflightInspectorTest`: ready, optional absence, required lost, required missing → unknown, required stale, empty list
- `BeaconSessionTest`: flag off → unknown; flag on logs and does not enable intervention

## Validation results

| Command | Result |
|---------|--------|
| Local `gradlew test` | hung on Gradle daemon in this environment; not used as evidence |
| GitHub Actions on this PR | required |

## Hardware validation

None. Desktop unit tests only.

## Documentation

`preflight.md`, `architecture.md`, `phases.md`, `testing.md`, `examples/README.md`, `README.md`, `CHANGELOG.md`

## Risks

Teams must declare expectations. An empty list is `UNKNOWN`, not an implied full-robot checklist.

## Rollback or disable strategy

Leave Phase 2 flags off (default). Revert the PR if needed.

## Known limitations

Does not discover Hubs or cameras by itself. Sibling reports still manual.

## Related issue

Closes #15. Part of #29.

## Phase / maturity impact

- [x] Phase 1 manual health reports (consumes registry)
- [x] Phase 2+ (preflight inspector only; no safety review for actuators because none are commanded)

## Safety

- [x] Does **not** enable motor, servo, or network intervention by default
- [x] Missing/stale observations fail safe
- [x] Does not use private SDK APIs in competition code
- [x] No secrets or private team data included

## Validation evidence

- [ ] `./gradlew check` passed locally
- [x] Unit tests added/updated
- [x] Hardware validation status: none

## Checklist

- [x] Docs updated if behavior or maturity labels changed
- [x] Citations distinguish verified fact vs inference vs hypothesis
- [x] Linked related issues / milestones
