### PR TITLE
Record health transitions and loop timing when Phase 3 is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Initial deep audit and priority ledger under `docs/audits/`.
 - CI for compile, unit tests, and relative documentation link checks.
 - Phase 2 `PreflightInspector`: required vs optional expectations against registry snapshots.
+- Phase 3 event history: when the flag is on, `BeaconSession` records `HEALTH_TRANSITION` on state changes and `LOOP_TIMING` on `observe()`. Default in-memory capacity remains 256.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Repository: **[The-Allsparks/BEACON](https://github.com/The-Allsparks/BEACON)**
 | Item | Status |
 |------|--------|
 | **Version** | `0.1.0-SNAPSHOT` |
-| **Implemented phase** | **Phase 0–2 types** (vocabulary, aging registry, preflight inspector). Flags for Phase 1+ default off. |
+| **Implemented phase** | **Phase 0–3 types** (vocabulary, aging registry, preflight inspector, bounded event history). Flags for Phase 1+ default off. |
 | **Phase 1** | Manual reports + time-correlated sampling (`FreshnessPolicy` overlay); flag default off; not hardware-validated |
 | **Phase 2** | `PreflightInspector` against registry snapshots; flag default off; no hardware probing |
-| **Phases 3–10** | Designed / experimental / **disabled by default** |
+| **Phase 3** | Automatic `HEALTH_TRANSITION` / `LOOP_TIMING` into the bounded logger; flag default off; Control Hub overhead not measured |
+| **Phases 4–10** | Designed / experimental / **disabled by default** |
 | **Active motor, servo, or network intervention** | **Disabled.** Do not enable without review and acceptance tests. |
 | **Driver Station early safe-stop** | **Not implemented.** No reliable supported public freshness API was verified. See [driver-link.md](docs/communications-health/driver-link.md). |
 | **Production safety claims** | **None.** This scaffold has not been validated on a real FTC robot. |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -3,10 +3,10 @@
 Living tracker for orchestrator selection. Update after each merged PR or when issue readiness changes.
 
 **Last updated:** 2026-08-18  
-**Audited commit:** `4bbe70f` (`main` after PR #38)  
+**Audited commit:** `b22bbaa` (`main` after PR #39)  
 **Automatic merge:** false except when the user explicitly says to proceed or continue on a ready PR  
 **Max active implementation subagents:** 1  
-**Open implementation PR:** issue #15 on `phase-2/15-preflight-inspector`
+**Open implementation PR:** issue #16 on `phase-3/16-event-history`
 
 ## Priority model
 
@@ -30,23 +30,26 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 ## Current selection
 
-PR #38 is merged (`Closes #31`). Current implementation: [#15](https://github.com/The-Allsparks/BEACON/issues/15) preflight inspector.
+PR #39 is merged (`Closes #15`). Current implementation: [#16](https://github.com/The-Allsparks/BEACON/issues/16) bounded event history. Software bound is logger capacity 256; Control Hub overhead stays on [#10](https://github.com/The-Allsparks/BEACON/issues/10).
 
 | Issue | Priority | Readiness | Dependencies | Current status | Assigned subagent | Branch | Pull request | CI status | Merge status | Blocker | Next action |
 |-------|----------|-----------|--------------|----------------|-------------------|--------|--------------|-----------|--------------|---------|-------------|
 | [#28](https://github.com/The-Allsparks/BEACON/pull/28) Phase 0 scaffold | done | merged | none | Merged | — | `scaffold/phase-0` | [#28](https://github.com/The-Allsparks/BEACON/pull/28) | success | merged | none | done |
 | [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | done | merged | #9, #10 software | Merged | — | `phase-1/30-freshness-sampling` | [#37](https://github.com/The-Allsparks/BEACON/pull/37) | success | merged | none | done |
 | [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | done | merged | none | Merged | — | `repo/31-pin-actions-shas` | [#38](https://github.com/The-Allsparks/BEACON/pull/38) | success | merged | none | done |
-| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | 1 | Ready | #30 | Implementing | orchestrator | `phase-2/15-preflight-inspector` | pending | pending | — | none | Test, open PR |
+| [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | done | merged | #30 | Merged | — | `phase-2/15-preflight-inspector` | [#39](https://github.com/The-Allsparks/BEACON/pull/39) | success | merged | none | done |
+| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 1 | Ready (software bound) | logger + #30 | Implementing | orchestrator | `phase-3/16-event-history` | pending | pending | — | Overhead unknown; software uses capacity 256 | Test, open PR |
 | [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 2 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
-| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry overhead AC | 3 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
-| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 4 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
-| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 5 | Not ready | #10 overhead | Open; logger exists | — | — | — | — | — | Overhead unknown | After measurement or bound |
+| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry / loop overhead | 3 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
+| [#17](https://github.com/The-Allsparks/BEACON/issues/17)–[#18](https://github.com/The-Allsparks/BEACON/issues/18) Phase 4 advisory/shadow | 4 | After #16 | #16 | Open | — | — | — | — | — | Phase 3 first | Do not start until #16 merges |
+| [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 5 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
 | [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 6 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
 | [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 7 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |
 | [#27](https://github.com/The-Allsparks/BEACON/issues/27) SystemCore | 8 | Blocked | authoritative docs | Open | — | — | — | — | — | No docs | Keep unavailable |
 | [#29](https://github.com/The-Allsparks/BEACON/issues/29) Roadmap epic | tracking | n/a | none | Open | orchestrator | n/a | n/a | n/a | n/a | none | Update after each merge |
-| Dependabot #33–#36 | deferred | not selected | compatibility analysis | Open PRs | — | dependabot/* | [#33](https://github.com/The-Allsparks/BEACON/pull/33)–[#36](https://github.com/The-Allsparks/BEACON/pull/36) | unknown | — | Major Gradle/JUnit/Actions upgrades | Do not merge without analysis |
+| Dependabot #33–#35 | deferred | not selected | compatibility analysis | Open PRs | — | dependabot/* | [#33](https://github.com/The-Allsparks/BEACON/pull/33)–[#35](https://github.com/The-Allsparks/BEACON/pull/35) | unknown | — | Major Gradle/JUnit/Actions upgrades | Do not merge without analysis |
+
+Note: Dependabot [#36](https://github.com/The-Allsparks/BEACON/pull/36) already merged `setup-java` **v5.7.0** onto `main` after the original v4 pin from #31.
 
 ## Phase 0 issue hygiene (software vs remaining AC)
 
@@ -59,10 +62,10 @@ Implemented in PR #28 tree; close **after merge** if remaining ACs are explicitl
 | #3 Stop latency | procedure only | Measurement | No — hardware |
 | #4 Gamepad timestamp | Javadoc yes | Hardware hold test | No — hardware |
 | #5 Module disconnect | research yes | Season SDK confirm | No — optional hardware |
-| #6 AdvantageKit/FRC patterns | yes | none | **Yes** |
-| #7 Build vs adopt | yes | none | **Yes** |
-| #8 Health-state vocabulary | yes | none | **Yes** |
-| #9 Immutable LinkHealth | yes | none | **Yes** |
+| #6 AdvantageKit/FRC patterns | yes | none | **Yes** (closed with #28) |
+| #7 Build vs adopt | yes | none | **Yes** (closed with #28) |
+| #8 Health-state vocabulary | yes | none | **Yes** (closed with #28) |
+| #9 Immutable LinkHealth | yes | none | **Yes** (closed with #28) |
 | #19 Command lease type | yes | Classroom exercise | No — learning AC |
 
 ## Stop conditions currently in effect
@@ -71,3 +74,4 @@ Implemented in PR #28 tree; close **after merge** if remaining ACs are explicitl
 - Do not implement Phase 5–9 active behavior.
 - Do not claim hardware validation.
 - One implementation PR at a time.
+- Do not merge Dependabot major bumps (#33 JUnit 6, #34 checkout v7, #35 Gradle 9) without compatibility analysis.

--- a/docs/communications-health/architecture.md
+++ b/docs/communications-health/architecture.md
@@ -58,6 +58,8 @@ Phase 2. `PreflightInspector.evaluate(registry, expectations)` classifies declar
 
 Phase 3–4. Initially a timeline (`BeaconEventLogger`), not a root-cause engine.
 
+Phase 3 (flag default off): `BeaconSession.report` and `BeaconSession.observe` record `HEALTH_TRANSITION` when `LinkState` changes. `observe` also records one `LOOP_TIMING` event. `snapshot()` does not log. First observation uses detail `NONE-><state>`. No AMPER/MIMIC/ViDAR/Pedro automatic adapters yet — those remain manual reports.
+
 ## SafeStateCoordinator
 
 Requests safe-state transitions from registered subsystems. It does not directly command every motor. `SafeStateRequest.shadowOnly` is the Phase 4 default.
@@ -68,7 +70,7 @@ Specifies whether recovery is allowed, attempt limit, backoff, timeout, and CPU 
 
 ## BeaconEventLogger
 
-Bounded rolling buffer. CSV header is TRACE-compatible:
+Bounded rolling buffer. Default `BeaconSession` capacity is 256. When full, the oldest event is dropped and `droppedCount` increases. CSV header is TRACE-compatible:
 
 `timestampNanos,type,linkId,domain,detail`
 

--- a/docs/communications-health/fault-correlation.md
+++ b/docs/communications-health/fault-correlation.md
@@ -2,6 +2,19 @@
 
 Phases 3–4. Initially a **timeline**, not a root-cause classifier.
 
+## Phase 3 automatic history
+
+When `BeaconFeatureFlags.eventHistory()` (or `phase3EventHistory(true)`) is set, `BeaconSession` records:
+
+- `HEALTH_TRANSITION` when a link’s `LinkState` changes, including the first observation (`NONE->…`). Unchanged states are not logged again.
+- `LOOP_TIMING` once per `observe()` call. `snapshot()` is a read and does not write history.
+
+The logger is a bounded in-memory ring (default session capacity **256**). Oldest events are dropped; `droppedCount()` is the only signal that history was truncated. Runtime does not write a second on-disk log stream.
+
+Call `observe()` once per OpMode loop if you want aging (`STALE` / `LOST` without a new report) to appear on the timeline. Reports also record transitions so tests and infrequent reporters do not need a loop tick.
+
+This is not a diagnosis. Events are timestamps, types, link ids, domains, and short details. Overhead on a Control Hub is still unmeasured ([issue #10](https://github.com/The-Allsparks/BEACON/issues/10)).
+
 ## Correlate, do not accuse
 
 Join timestamps for:

--- a/docs/communications-health/phases.md
+++ b/docs/communications-health/phases.md
@@ -40,6 +40,8 @@ Rolling timeline of health, loop duration, AMPER voltage, mechanism activity, ca
 
 **Acceptance:** post-match timelines distinguish major domains; logging is bounded.
 
+**Status:** bounded logger records `HEALTH_TRANSITION` and `LOOP_TIMING` when the Phase 3 flag is on; default session capacity is 256; flag default off; Control Hub overhead not measured.
+
 ## Phase 4 — Advisory correlation and shadow safe state
 
 **Teach:** What evidence supports a diagnosis?

--- a/docs/communications-health/testing.md
+++ b/docs/communications-health/testing.md
@@ -2,7 +2,7 @@
 
 ## Unit tests (Phase 0, implemented)
 
-Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`, preflight required vs optional (optional absence `READY_DEGRADED`, required missing evidence `UNKNOWN`, required `LOST`/`STALE` `NOT_READY`).
+Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`, preflight required vs optional (optional absence `READY_DEGRADED`, required missing evidence `UNKNOWN`, required `LOST`/`STALE` `NOT_READY`), Phase 3 auto `HEALTH_TRANSITION` / `LOOP_TIMING` (flag off is silent; first observation `NONE->…`; unchanged state is not re-logged; aging appears on `observe()` not `snapshot()`; `droppedCount` when full).
 
 ## Simulation tests (Phase 0, partial)
 
@@ -34,4 +34,4 @@ Maximum initial drive power for any future Phase 5 test: low enough that a misse
 
 ## Overhead
 
-Call `BeaconSession.lastObserveDurationNanos()` in Phase 1. Acceptance requires measuring loop overhead on a Control Hub before enabling logging-heavy phases.
+Call `BeaconSession.lastObserveDurationNanos()` after `observe()` or `report()`. Software bounds logging at logger capacity (default 256). Acceptance still requires measuring loop overhead on a Control Hub ([issue #10](https://github.com/The-Allsparks/BEACON/issues/10)); this library does not claim that measurement.

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,18 @@ PreflightReport preflight = beacon.preflight(Arrays.asList(
 
 The inspector does not command actuators and does not invent a Driver Station heartbeat. A required link with no report is `UNKNOWN`.
 
+## Phase 3 — bounded event history
+
+```java
+BeaconSession beacon = BeaconSession.create(BeaconFeatureFlags.eventHistory());
+beacon.report(HealthReport.healthy(
+        LinkId.of("frontCamera"), FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
+beacon.observe(); // once per loop: ages snapshots and records LOOP_TIMING
+String csv = beacon.logger().exportCsv();
+```
+
+This is an in-memory timeline, not a diagnosis. Oldest events drop when the logger is full (`droppedCount()`). Do not add a second runtime log stream.
+
 ## Later phases
 
 Do not enable from examples until acceptance tests in [phases.md](../docs/communications-health/phases.md) pass and maintainers review. Driver Station safe-stop remains research-only until a supported freshness source is proven.

--- a/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
+++ b/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
@@ -177,4 +177,12 @@ public final class BeaconFeatureFlags {
     public static BeaconFeatureFlags preflight() {
         return builder().phase1ManualReports(true).phase2Preflight(true).build();
     }
+
+    /**
+     * Phase 0–3: manual reports plus bounded health-transition and loop-timing
+     * history. No output intervention.
+     */
+    public static BeaconFeatureFlags eventHistory() {
+        return builder().phase1ManualReports(true).phase3EventHistory(true).build();
+    }
 }

--- a/src/main/java/org/allsparks/beacon/BeaconSession.java
+++ b/src/main/java/org/allsparks/beacon/BeaconSession.java
@@ -1,11 +1,14 @@
 package org.allsparks.beacon;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.allsparks.beacon.api.FailureDomain;
 import org.allsparks.beacon.api.HealthReport;
 import org.allsparks.beacon.api.LinkHealth;
 import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
 import org.allsparks.beacon.clock.BeaconClock;
 import org.allsparks.beacon.clock.SystemNanoClock;
 import org.allsparks.beacon.health.HealthRegistry;
@@ -23,10 +26,14 @@ import org.allsparks.beacon.preflight.PreflightStatus;
  * or network hardware.
  */
 public final class BeaconSession {
+    /** Default in-memory history bound used by {@link #create()} factories. */
+    public static final int DEFAULT_LOGGER_CAPACITY = 256;
+
     private final BeaconFeatureFlags flags;
     private final BeaconClock clock;
     private final HealthRegistry registry;
     private final BeaconEventLogger logger;
+    private final Map<LinkId, LinkState> lastLoggedStates = new HashMap<>();
     private long observeCount;
     private long lastObserveDurationNanos;
 
@@ -37,12 +44,17 @@ public final class BeaconSession {
         this.logger = new BeaconEventLogger(loggerCapacity);
     }
 
+    /**
+     * Create a session with default flags and a 256-event in-memory logger.
+     * That capacity is the software bound for Phase 3 history; it is not a
+     * Control Hub overhead measurement.
+     */
     public static BeaconSession create() {
-        return new BeaconSession(BeaconFeatureFlags.defaults(), new SystemNanoClock(), 256);
+        return new BeaconSession(BeaconFeatureFlags.defaults(), new SystemNanoClock(), DEFAULT_LOGGER_CAPACITY);
     }
 
     public static BeaconSession create(BeaconFeatureFlags flags) {
-        return new BeaconSession(flags, new SystemNanoClock(), 256);
+        return new BeaconSession(flags, new SystemNanoClock(), DEFAULT_LOGGER_CAPACITY);
     }
 
     /**
@@ -61,6 +73,9 @@ public final class BeaconSession {
                     report.id(),
                     report.domain(),
                     report.reporter() + ": " + report.reportedState()));
+        }
+        if (flags.isPhase3EventHistory()) {
+            recordHealthTransition(health, start);
         }
         lastObserveDurationNanos = clock.nanoTime() - start;
         observeCount++;
@@ -136,5 +151,45 @@ public final class BeaconSession {
                 FailureDomain.SOFTWARE_LOOP,
                 report.status().name()));
         return report;
+    }
+
+    /**
+     * Sample all registered links. When Phase 3 is enabled, records health
+     * transitions discovered by freshness aging and one loop-timing event.
+     * Does not command actuators. Logging is bounded by logger capacity.
+     */
+    public List<LinkHealth> observe() {
+        long start = clock.nanoTime();
+        List<LinkHealth> snap = registry.snapshot();
+        if (flags.isPhase3EventHistory()) {
+            for (LinkHealth health : snap) {
+                recordHealthTransition(health, start);
+            }
+        }
+        lastObserveDurationNanos = clock.nanoTime() - start;
+        observeCount++;
+        if (flags.isPhase3EventHistory()) {
+            logger.record(new BeaconEvent(
+                    start,
+                    BeaconEventType.LOOP_TIMING,
+                    LinkId.of("loop"),
+                    FailureDomain.SOFTWARE_LOOP,
+                    Long.toString(lastObserveDurationNanos)));
+        }
+        return snap;
+    }
+
+    private void recordHealthTransition(LinkHealth health, long timestampNanos) {
+        LinkState previous = lastLoggedStates.put(health.id(), health.state());
+        if (previous == health.state()) {
+            return;
+        }
+        String from = previous == null ? "NONE" : previous.name();
+        logger.record(new BeaconEvent(
+                timestampNanos,
+                BeaconEventType.HEALTH_TRANSITION,
+                health.id(),
+                health.domain(),
+                from + "->" + health.state().name()));
     }
 }

--- a/src/test/java/org/allsparks/beacon/EventHistoryTest.java
+++ b/src/test/java/org/allsparks/beacon/EventHistoryTest.java
@@ -1,0 +1,163 @@
+package org.allsparks.beacon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.allsparks.beacon.api.Confidence;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.HealthReport;
+import org.allsparks.beacon.api.LinkFailureReason;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.clock.FakeClock;
+import org.allsparks.beacon.log.BeaconEvent;
+import org.allsparks.beacon.log.BeaconEventType;
+import org.junit.jupiter.api.Test;
+
+class EventHistoryTest {
+    private static final LinkId CAMERA = LinkId.of("frontCamera");
+
+    @Test
+    void defaultSessionUsesBoundedLoggerCapacity() {
+        BeaconSession session = BeaconSession.create(BeaconFeatureFlags.eventHistory());
+        assertEquals(BeaconSession.DEFAULT_LOGGER_CAPACITY, session.logger().capacity());
+        assertEquals(256, session.logger().capacity());
+        assertFalse(session.isInterventionEnabled());
+    }
+
+    @Test
+    void phase3OffDoesNotRecordTransitionsOrTiming() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.defaults(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(81);
+        session.observe();
+        session.snapshot();
+        assertEquals(0, session.logger().size());
+        assertFalse(session.isInterventionEnabled());
+    }
+
+    @Test
+    void firstReportRecordsNoneToCurrentState() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.eventHistory(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        assertEquals(1, count(session, BeaconEventType.HEALTH_TRANSITION));
+        assertEquals("NONE->HEALTHY", first(session, BeaconEventType.HEALTH_TRANSITION).detail());
+        assertEquals(CAMERA, first(session, BeaconEventType.HEALTH_TRANSITION).linkId());
+        assertEquals(0, count(session, BeaconEventType.LOOP_TIMING));
+        assertFalse(session.isInterventionEnabled());
+    }
+
+    @Test
+    void unchangedStateDoesNotRecordAnotherTransition() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.eventHistory(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(1);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, clock.nanoTime(), "ViDAR"));
+        session.observe();
+        assertEquals(1, count(session, BeaconEventType.HEALTH_TRANSITION));
+        assertEquals(1, count(session, BeaconEventType.LOOP_TIMING));
+    }
+
+    @Test
+    void explicitStateChangeRecordsTransition() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.eventHistory(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        session.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                2L,
+                "ViDAR",
+                "pipeline stopped",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.8)));
+        assertEquals(2, count(session, BeaconEventType.HEALTH_TRANSITION));
+        assertEquals("HEALTHY->LOST", last(session, BeaconEventType.HEALTH_TRANSITION).detail());
+        assertEquals(0, count(session, BeaconEventType.LOOP_TIMING));
+    }
+
+    @Test
+    void observeRecordsAgingTransitionAndLoopTiming() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.eventHistory(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        clock.advanceMillis(81);
+        session.observe();
+        assertEquals(2, count(session, BeaconEventType.HEALTH_TRANSITION));
+        assertEquals("HEALTHY->STALE", last(session, BeaconEventType.HEALTH_TRANSITION).detail());
+        assertEquals(1, count(session, BeaconEventType.LOOP_TIMING));
+        assertEquals(LinkId.of("loop"), first(session, BeaconEventType.LOOP_TIMING).linkId());
+        assertEquals(FailureDomain.SOFTWARE_LOOP, first(session, BeaconEventType.LOOP_TIMING).domain());
+    }
+
+    @Test
+    void snapshotDoesNotRecordEvents() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.eventHistory(), clock, 16);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        int afterReport = session.logger().size();
+        clock.advanceMillis(81);
+        session.snapshot();
+        assertEquals(afterReport, session.logger().size());
+        assertEquals(LinkState.STALE, session.snapshot().get(0).state());
+    }
+
+    @Test
+    void droppedCountIncrementsWhenHistoryIsFull() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(
+                BeaconFeatureFlags.builder().phase3EventHistory(true).build(), clock, 1);
+        session.report(HealthReport.healthy(CAMERA, FailureDomain.USB_CAMERA, 1L, "ViDAR"));
+        session.report(new HealthReport(
+                CAMERA,
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                2L,
+                "ViDAR",
+                "pipeline stopped",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.8)));
+        assertEquals(1, session.logger().size());
+        assertEquals(1, session.logger().capacity());
+        assertEquals(1L, session.logger().droppedCount());
+        assertTrue(session.logger().exportCsv().contains("HEALTH_TRANSITION"));
+        assertFalse(session.flags().isAnyInterventionEnabled());
+    }
+
+    private static int count(BeaconSession session, BeaconEventType type) {
+        int n = 0;
+        for (BeaconEvent event : session.logger().snapshot()) {
+            if (event.type() == type) {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    private static BeaconEvent first(BeaconSession session, BeaconEventType type) {
+        for (BeaconEvent event : session.logger().snapshot()) {
+            if (event.type() == type) {
+                return event;
+            }
+        }
+        throw new AssertionError("missing " + type);
+    }
+
+    private static BeaconEvent last(BeaconSession session, BeaconEventType type) {
+        BeaconEvent found = null;
+        for (BeaconEvent event : session.logger().snapshot()) {
+            if (event.type() == type) {
+                found = event;
+            }
+        }
+        if (found == null) {
+            throw new AssertionError("missing " + type);
+        }
+        return found;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 now records a bounded in-memory timeline when the feature flag is on. `BeaconSession` logs `HEALTH_TRANSITION` on `LinkState` changes (including first observation `NONE->…`) and one `LOOP_TIMING` event per `observe()`. `snapshot()` remains a read.

Closes #16. Control Hub loop overhead is still unmeasured and stays on #10. Default logger capacity is 256; oldest events drop and `droppedCount()` records truncation.

## Problem

The logger and CSV export already existed, but nothing recorded health transitions or loop timing automatically. Post-match timelines could not show what changed immediately before a failure.

## Solution

- `BeaconFeatureFlags.eventHistory()` enables Phase 1 reports plus Phase 3 history (no actuators)
- First observation logs `NONE-><state>`; unchanged states are not re-logged
- Aging (`STALE` / `LOST` without a new report) appears on `observe()`, not on `snapshot()`
- Reports also record transitions so tests do not need a loop tick
- Software bound is logger capacity 256; this is not a Control Hub measurement

## Scope

- Session wiring, helper flag, unit tests, docs/examples/changelog/ledger

## Out of scope

- Root-cause / advisory labels (Phase 4)
- Disk logs or a second runtime stream
- AMPER/MIMIC/ViDAR/Pedro automatic adapters
- Hardware overhead measurement (#10)
- Phase 5+ intervention

## Test plan

- [x] Flag off: no auto transitions or loop timing
- [x] First report: `NONE->HEALTHY`
- [x] Unchanged state: no extra transition
- [x] Explicit `HEALTHY->LOST`
- [x] Clock-aged `HEALTHY->STALE` on `observe()` plus `LOOP_TIMING`
- [x] `snapshot()` does not write history
- [x] `droppedCount` when capacity is 1
- [x] `isAnyInterventionEnabled()` remains false
- [ ] GitHub Actions `check` on Ubuntu and Windows
- [ ] Docs-structure relative links

Local `gradlew` was not used as a gate (known hang in this environment).