### PR TITLE
Add fixture-based Phase 4 advisory correlator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - CI for compile, unit tests, and relative documentation link checks.
 - Phase 2 `PreflightInspector`: required vs optional expectations against registry snapshots.
 - Phase 3 event history: when the flag is on, `BeaconSession` records `HEALTH_TRANSITION` on state changes and `LOOP_TIMING` on `observe()`. Default in-memory capacity remains 256.
+- Phase 4 advisory correlator: `EventCorrelator` emits one label with confidence and evidence. Simultaneous multi-family failures without electrical/AMPER evidence are `INSUFFICIENT_EVIDENCE`. No jamming label.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Repository: **[The-Allsparks/BEACON](https://github.com/The-Allsparks/BEACON)**
 | Item | Status |
 |------|--------|
 | **Version** | `0.1.0-SNAPSHOT` |
-| **Implemented phase** | **Phase 0–3 types** (vocabulary, aging registry, preflight inspector, bounded event history). Flags for Phase 1+ default off. |
+| **Implemented phase** | **Phase 0–4 types** (vocabulary, aging registry, preflight, bounded history, advisory correlator). Flags for Phase 1+ default off. |
 | **Phase 1** | Manual reports + time-correlated sampling (`FreshnessPolicy` overlay); flag default off; not hardware-validated |
 | **Phase 2** | `PreflightInspector` against registry snapshots; flag default off; no hardware probing |
 | **Phase 3** | Automatic `HEALTH_TRANSITION` / `LOOP_TIMING` into the bounded logger; flag default off; Control Hub overhead not measured |
-| **Phases 4–10** | Designed / experimental / **disabled by default** |
+| **Phase 4** | Advisory labels from snapshot + events; flag default off; no match false-fault review; shadow safe-stop not implemented |
+| **Phases 5–10** | Designed / experimental / **disabled by default** |
 | **Active motor, servo, or network intervention** | **Disabled.** Do not enable without review and acceptance tests. |
 | **Driver Station early safe-stop** | **Not implemented.** No reliable supported public freshness API was verified. See [driver-link.md](docs/communications-health/driver-link.md). |
 | **Production safety claims** | **None.** This scaffold has not been validated on a real FTC robot. |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -3,10 +3,10 @@
 Living tracker for orchestrator selection. Update after each merged PR or when issue readiness changes.
 
 **Last updated:** 2026-08-18  
-**Audited commit:** `b22bbaa` (`main` after PR #39)  
+**Audited commit:** `7b27023` (`main` after PR #40)  
 **Automatic merge:** false except when the user explicitly says to proceed or continue on a ready PR  
 **Max active implementation subagents:** 1  
-**Open implementation PR:** issue #16 on `phase-3/16-event-history`
+**Open implementation PR:** issue #17 software slice on `phase-4/17-advisory-correlation`
 
 ## Priority model
 
@@ -30,7 +30,7 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 ## Current selection
 
-PR #39 is merged (`Closes #15`). Current implementation: [#16](https://github.com/The-Allsparks/BEACON/issues/16) bounded event history. Software bound is logger capacity 256; Control Hub overhead stays on [#10](https://github.com/The-Allsparks/BEACON/issues/10).
+PR #40 is merged (`Closes #16` software; overhead stays on #10). Current implementation: [#17](https://github.com/The-Allsparks/BEACON/issues/17) advisory correlator (software fixtures). Match false-fault review and sibling adapters remain open on #17. Shadow safe-stop is [#18](https://github.com/The-Allsparks/BEACON/issues/18).
 
 | Issue | Priority | Readiness | Dependencies | Current status | Assigned subagent | Branch | Pull request | CI status | Merge status | Blocker | Next action |
 |-------|----------|-----------|--------------|----------------|-------------------|--------|--------------|-----------|--------------|---------|-------------|
@@ -38,10 +38,11 @@ PR #39 is merged (`Closes #15`). Current implementation: [#16](https://github.co
 | [#30](https://github.com/The-Allsparks/BEACON/issues/30) Freshness-aware sampling | done | merged | #9, #10 software | Merged | — | `phase-1/30-freshness-sampling` | [#37](https://github.com/The-Allsparks/BEACON/pull/37) | success | merged | none | done |
 | [#31](https://github.com/The-Allsparks/BEACON/issues/31) Pin Actions SHAs | done | merged | none | Merged | — | `repo/31-pin-actions-shas` | [#38](https://github.com/The-Allsparks/BEACON/pull/38) | success | merged | none | done |
 | [#15](https://github.com/The-Allsparks/BEACON/issues/15) Preflight inspector | done | merged | #30 | Merged | — | `phase-2/15-preflight-inspector` | [#39](https://github.com/The-Allsparks/BEACON/pull/39) | success | merged | none | done |
-| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | 1 | Ready (software bound) | logger + #30 | Implementing | orchestrator | `phase-3/16-event-history` | pending | pending | — | Overhead unknown; software uses capacity 256 | Test, open PR |
-| [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 2 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
-| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry / loop overhead | 3 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
-| [#17](https://github.com/The-Allsparks/BEACON/issues/17)–[#18](https://github.com/The-Allsparks/BEACON/issues/18) Phase 4 advisory/shadow | 4 | After #16 | #16 | Open | — | — | — | — | — | Phase 3 first | Do not start until #16 merges |
+| [#16](https://github.com/The-Allsparks/BEACON/issues/16) Auto event history | done | merged | logger + #30 | Merged | — | `phase-3/16-event-history` | [#40](https://github.com/The-Allsparks/BEACON/pull/40) | success | merged | none | Overhead remains #10 |
+| [#17](https://github.com/The-Allsparks/BEACON/issues/17) Advisory correlator | 1 | Ready (software split) | #16 | Implementing | orchestrator | `phase-4/17-advisory-correlation` | pending | pending | — | Match review; sibling DTOs | Test, open PR; do not close #17 |
+| [#18](https://github.com/The-Allsparks/BEACON/issues/18) Shadow safe-stop | 2 | Blocked | public freshness / match logs | Open | — | — | — | — | — | No public DS heartbeat | Do not invent a detector |
+| [#32](https://github.com/The-Allsparks/BEACON/issues/32) Branch protection | 3 | Blocked on human policy | none | Open | — | n/a | — | — | — | Who must approve? | Maintainer decision |
+| [#10](https://github.com/The-Allsparks/BEACON/issues/10) Registry / loop overhead | 4 | Blocked on hardware | none | Open; software done | — | — | — | — | — | Control Hub | Measure when available |
 | [#11](https://github.com/The-Allsparks/BEACON/issues/11)–[#14](https://github.com/The-Allsparks/BEACON/issues/14) Sibling reports | 5 | Blocked on sibling DTOs | #10 | Open; docs exist | — | — | — | — | — | Sibling contracts | Manual `HealthReport` only |
 | [#3](https://github.com/The-Allsparks/BEACON/issues/3) Stop latency | 6 | Blocked on hardware | adult supervision | Open | — | — | — | — | — | Restrained robot | Do not fake as hardware |
 | [#2](https://github.com/The-Allsparks/BEACON/issues/2)/[#20](https://github.com/The-Allsparks/BEACON/issues/20)/[#21](https://github.com/The-Allsparks/BEACON/issues/21) DS safe-stop | 7 | Blocked | public freshness API | Open | — | — | — | — | — | Readiness gate unmet | Do not implement |

--- a/docs/communications-health/architecture.md
+++ b/docs/communications-health/architecture.md
@@ -60,6 +60,8 @@ Phase 3–4. Initially a timeline (`BeaconEventLogger`), not a root-cause engine
 
 Phase 3 (flag default off): `BeaconSession.report` and `BeaconSession.observe` record `HEALTH_TRANSITION` when `LinkState` changes. `observe` also records one `LOOP_TIMING` event. `snapshot()` does not log. First observation uses detail `NONE-><state>`. No AMPER/MIMIC/ViDAR/Pedro automatic adapters yet — those remain manual reports.
 
+Phase 4 advisory (flag default off): `EventCorrelator.evaluate(events, snapshot)` emits one `AdvisoryLabel` with `Confidence` and evidence. Isolated single-family failures may receive a probable label; simultaneous multi-family failures without electrical/AMPER evidence are `INSUFFICIENT_EVIDENCE`. Driver Station domains are not diagnosed here. `BeaconSession.advise()` does not command actuators and does not log `SHADOW_SAFE_STATE`.
+
 ## SafeStateCoordinator
 
 Requests safe-state transitions from registered subsystems. It does not directly command every motor. `SafeStateRequest.shadowOnly` is the Phase 4 default.

--- a/docs/communications-health/fault-correlation.md
+++ b/docs/communications-health/fault-correlation.md
@@ -30,11 +30,27 @@ Join timestamps for:
 
 ## Advisory labels (Phase 4)
 
+`EventCorrelator.evaluate(events, snapshot)` returns **one** label with a confidence and an evidence list. `BeaconSession.advise()` is off unless `BeaconFeatureFlags.advisory()` (or `phase4AdvisoryShadow(true)`) is set. Disabled calls return `INSUFFICIENT_EVIDENCE` with unknown confidence.
+
+Labels:
+
 - probable power-related disruption
 - probable isolated camera failure
 - probable Expansion Hub path failure
 - probable loop overrun
 - insufficient evidence
+
+Rules used in software (desktop fixtures, not match-validated):
+
+- `STALE` / `LOST` links count as failed. `UNKNOWN` and `HEALTHY` do not.
+- A **single** domain family (camera / hub-path / electrical / loop-overrun) may receive that family’s probable label at confidence `0.5`.
+- Software-loop loss **without** reason `LOOP_OVERRUN` is `INSUFFICIENT_EVIDENCE`.
+- Driver Station / gamepad domains are `INSUFFICIENT_EVIDENCE` (this is not a heartbeat detector).
+- Two or more families without electrical or AMPER voltage evidence → `INSUFFICIENT_EVIDENCE`.
+- Electrical or `AMPER_VOLTAGE` evidence **plus** other failed families → `PROBABLE_POWER_DISRUPTION` at confidence `0.4`, with all evidence listed. That is not a unique cause and is **not** jamming.
+- There is no jamming or malicious-interference label.
+
+Sibling ViDAR/MIMIC/AMPER/Pedro adapters are not required: tests and OpModes may submit `HealthReport` / `BeaconEvent` fixtures. Post-match false-fault review remains issue #17. Shadow safe-stop logging remains issue #18.
 
 Every label needs a confidence and the evidence list. Simultaneous failures are often **misleading** (brownout plus Hub loss plus camera USB reset). Prefer `INSUFFICIENT_EVIDENCE` over a dramatic story.
 

--- a/docs/communications-health/phases.md
+++ b/docs/communications-health/phases.md
@@ -56,6 +56,8 @@ Output intervention: DISABLED
 
 **Acceptance:** classifications include confidence; shadow through full matches; no outputs change.
 
+**Status:** advisory correlator implemented against snapshot + event fixtures; flag default off; no sibling adapters; no match false-fault review; shadow safe-stop logging not implemented.
+
 ## Phase 5 — Drivetrain communication safe stop
 
 **Teach:** Why should a command expire?

--- a/docs/communications-health/testing.md
+++ b/docs/communications-health/testing.md
@@ -2,7 +2,7 @@
 
 ## Unit tests (Phase 0, implemented)
 
-Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`, preflight required vs optional (optional absence `READY_DEGRADED`, required missing evidence `UNKNOWN`, required `LOST`/`STALE` `NOT_READY`), Phase 3 auto `HEALTH_TRANSITION` / `LOOP_TIMING` (flag off is silent; first observation `NONE->…`; unchanged state is not re-logged; aging appears on `observe()` not `snapshot()`; `droppedCount` when full).
+Covered now: health-state construction, freshness thresholds, hysteresis windows, confidence absence, rolling event history, command-lease expiration, recovery inhibit, neutral-control detection, bounded retry math, missing data, fake clocks, registry clock-advance aging (`STALE` / `LOST` without a new report), consecutive report counts, timestamp `0` → `UNKNOWN`, preflight required vs optional (optional absence `READY_DEGRADED`, required missing evidence `UNKNOWN`, required `LOST`/`STALE` `NOT_READY`), Phase 3 auto `HEALTH_TRANSITION` / `LOOP_TIMING` (flag off is silent; first observation `NONE->…`; unchanged state is not re-logged; aging appears on `observe()` not `snapshot()`; `droppedCount` when full), Phase 4 advisory labels (isolated camera/hub/power/loop-overrun; simultaneous multi-family without AMPER → `INSUFFICIENT_EVIDENCE`; AMPER plus companions → low-confidence power, not jamming; flag off is insufficient; no DS heartbeat diagnosis).
 
 ## Simulation tests (Phase 0, partial)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,6 +70,26 @@ String csv = beacon.logger().exportCsv();
 
 This is an in-memory timeline, not a diagnosis. Oldest events drop when the logger is full (`droppedCount()`). Do not add a second runtime log stream.
 
+## Phase 4 — advisory correlation
+
+```java
+BeaconSession beacon = BeaconSession.create(BeaconFeatureFlags.advisory());
+beacon.report(new HealthReport(
+        LinkId.of("frontCamera"),
+        FailureDomain.USB_CAMERA,
+        LinkState.LOST,
+        clock.nanoTime(),
+        "ViDAR",
+        "pipeline stopped",
+        LinkFailureReason.EXPLICIT_LOSS_REPORT,
+        Confidence.of(0.8)));
+AdvisoryReport advice = beacon.advise();
+// Isolated camera → PROBABLE_ISOLATED_CAMERA_FAILURE.
+// Camera + Hub without AMPER → INSUFFICIENT_EVIDENCE, not "jamming."
+```
+
+This does not command actuators and does not log a shadow Driver Station safe-stop.
+
 ## Later phases
 
 Do not enable from examples until acceptance tests in [phases.md](../docs/communications-health/phases.md) pass and maintainers review. Driver Station safe-stop remains research-only until a supported freshness source is proven.

--- a/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
+++ b/src/main/java/org/allsparks/beacon/BeaconFeatureFlags.java
@@ -185,4 +185,17 @@ public final class BeaconFeatureFlags {
     public static BeaconFeatureFlags eventHistory() {
         return builder().phase1ManualReports(true).phase3EventHistory(true).build();
     }
+
+    /**
+     * Phase 0–4 advisory: manual reports, event history, and correlator.
+     * Does not enable actuator intervention. Shadow safe-stop logging is not
+     * implemented by this helper (issue #18).
+     */
+    public static BeaconFeatureFlags advisory() {
+        return builder()
+                .phase1ManualReports(true)
+                .phase3EventHistory(true)
+                .phase4AdvisoryShadow(true)
+                .build();
+    }
 }

--- a/src/main/java/org/allsparks/beacon/BeaconSession.java
+++ b/src/main/java/org/allsparks/beacon/BeaconSession.java
@@ -1,9 +1,11 @@
 package org.allsparks.beacon;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.allsparks.beacon.api.Confidence;
 import org.allsparks.beacon.api.FailureDomain;
 import org.allsparks.beacon.api.HealthReport;
 import org.allsparks.beacon.api.LinkHealth;
@@ -11,6 +13,10 @@ import org.allsparks.beacon.api.LinkId;
 import org.allsparks.beacon.api.LinkState;
 import org.allsparks.beacon.clock.BeaconClock;
 import org.allsparks.beacon.clock.SystemNanoClock;
+import org.allsparks.beacon.correlate.AdvisoryEvidence;
+import org.allsparks.beacon.correlate.AdvisoryLabel;
+import org.allsparks.beacon.correlate.AdvisoryReport;
+import org.allsparks.beacon.correlate.EventCorrelator;
 import org.allsparks.beacon.health.HealthRegistry;
 import org.allsparks.beacon.log.BeaconEvent;
 import org.allsparks.beacon.log.BeaconEventLogger;
@@ -150,6 +156,34 @@ public final class BeaconSession {
                 LinkId.of("preflight"),
                 FailureDomain.SOFTWARE_LOOP,
                 report.status().name()));
+        return report;
+    }
+
+    /**
+     * Classify current snapshot and event history into one advisory label.
+     * Does not command actuators and does not log a shadow safe-stop (Phase 4
+     * shadow remains issue #18). When Phase 4 is disabled, the result is
+     * {@link AdvisoryLabel#INSUFFICIENT_EVIDENCE} rather than a fabricated cause.
+     */
+    public AdvisoryReport advise() {
+        if (!flags.isPhase4AdvisoryShadow()) {
+            AdvisoryEvidence evidence = new AdvisoryEvidence(
+                    LinkId.of("correlator"),
+                    FailureDomain.UNKNOWN,
+                    "Phase 4 advisory correlation is disabled by feature flags.");
+            return AdvisoryReport.of(
+                    AdvisoryLabel.INSUFFICIENT_EVIDENCE,
+                    Confidence.unknown(),
+                    Collections.singletonList(evidence),
+                    "Phase 4 advisory correlation is disabled by feature flags.");
+        }
+        AdvisoryReport report = EventCorrelator.evaluate(logger.snapshot(), registry.snapshot());
+        logger.record(new BeaconEvent(
+                clock.nanoTime(),
+                BeaconEventType.FAILURE_DOMAIN_HINT,
+                LinkId.of("correlator"),
+                FailureDomain.UNKNOWN,
+                report.label().name()));
         return report;
     }
 

--- a/src/main/java/org/allsparks/beacon/correlate/AdvisoryEvidence.java
+++ b/src/main/java/org/allsparks/beacon/correlate/AdvisoryEvidence.java
@@ -1,0 +1,33 @@
+package org.allsparks.beacon.correlate;
+
+import java.util.Objects;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.LinkId;
+
+/** One observation supporting an {@link AdvisoryReport}. Not a root cause. */
+public final class AdvisoryEvidence {
+    private final LinkId linkId;
+    private final FailureDomain domain;
+    private final String detail;
+
+    public AdvisoryEvidence(LinkId linkId, FailureDomain domain, String detail) {
+        this.linkId = Objects.requireNonNull(linkId, "linkId");
+        this.domain = domain == null ? FailureDomain.UNKNOWN : domain;
+        this.detail = detail == null ? "" : detail;
+        if (this.detail.trim().isEmpty()) {
+            throw new IllegalArgumentException("Advisory evidence must include a detail");
+        }
+    }
+
+    public LinkId linkId() {
+        return linkId;
+    }
+
+    public FailureDomain domain() {
+        return domain;
+    }
+
+    public String detail() {
+        return detail;
+    }
+}

--- a/src/main/java/org/allsparks/beacon/correlate/AdvisoryLabel.java
+++ b/src/main/java/org/allsparks/beacon/correlate/AdvisoryLabel.java
@@ -1,0 +1,13 @@
+package org.allsparks.beacon.correlate;
+
+/**
+ * Advisory-only diagnoses. There is no jamming or malicious-interference label.
+ * Prefer {@link #INSUFFICIENT_EVIDENCE} when more than one story fits.
+ */
+public enum AdvisoryLabel {
+    PROBABLE_POWER_DISRUPTION,
+    PROBABLE_ISOLATED_CAMERA_FAILURE,
+    PROBABLE_EXPANSION_HUB_PATH_FAILURE,
+    PROBABLE_LOOP_OVERRUN,
+    INSUFFICIENT_EVIDENCE
+}

--- a/src/main/java/org/allsparks/beacon/correlate/AdvisoryReport.java
+++ b/src/main/java/org/allsparks/beacon/correlate/AdvisoryReport.java
@@ -1,0 +1,64 @@
+package org.allsparks.beacon.correlate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.allsparks.beacon.api.Confidence;
+
+/**
+ * One advisory classification. Always includes a label, a confidence (possibly
+ * {@link Confidence#unknown()}), an evidence list, and an explanation.
+ * Does not command actuators.
+ */
+public final class AdvisoryReport {
+    private final AdvisoryLabel label;
+    private final Confidence confidence;
+    private final List<AdvisoryEvidence> evidence;
+    private final String explanation;
+
+    public AdvisoryReport(
+            AdvisoryLabel label,
+            Confidence confidence,
+            List<AdvisoryEvidence> evidence,
+            String explanation) {
+        this.label = Objects.requireNonNull(label, "label");
+        this.confidence = Objects.requireNonNull(confidence, "confidence");
+        Objects.requireNonNull(evidence, "evidence");
+        this.evidence = Collections.unmodifiableList(new ArrayList<>(evidence));
+        this.explanation = Objects.requireNonNull(explanation, "explanation");
+        if (this.explanation.trim().isEmpty()) {
+            throw new IllegalArgumentException("Advisory reports must include an explanation");
+        }
+        if (this.evidence.isEmpty()) {
+            throw new IllegalArgumentException("Advisory reports must include evidence");
+        }
+        for (AdvisoryEvidence item : this.evidence) {
+            Objects.requireNonNull(item, "evidence item");
+        }
+    }
+
+    public static AdvisoryReport of(
+            AdvisoryLabel label,
+            Confidence confidence,
+            List<AdvisoryEvidence> evidence,
+            String explanation) {
+        return new AdvisoryReport(label, confidence, evidence, explanation);
+    }
+
+    public AdvisoryLabel label() {
+        return label;
+    }
+
+    public Confidence confidence() {
+        return confidence;
+    }
+
+    public List<AdvisoryEvidence> evidence() {
+        return evidence;
+    }
+
+    public String explanation() {
+        return explanation;
+    }
+}

--- a/src/main/java/org/allsparks/beacon/correlate/EventCorrelator.java
+++ b/src/main/java/org/allsparks/beacon/correlate/EventCorrelator.java
@@ -1,0 +1,207 @@
+package org.allsparks.beacon.correlate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.allsparks.beacon.api.Confidence;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.LinkFailureReason;
+import org.allsparks.beacon.api.LinkHealth;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.log.BeaconEvent;
+import org.allsparks.beacon.log.BeaconEventType;
+
+/**
+ * Phase 4 advisory correlator. Classifies a snapshot plus event timeline into
+ * one label with confidence and evidence. Does not probe devices, capture
+ * Wi-Fi, claim jamming, or command actuators.
+ *
+ * <p>Simultaneous failures in more than one domain family default to
+ * {@link AdvisoryLabel#INSUFFICIENT_EVIDENCE} unless electrical or AMPER
+ * voltage evidence is present, in which case the power label is used at low
+ * confidence rather than inventing a single non-power cause.
+ */
+public final class EventCorrelator {
+    static final Confidence ISOLATED = Confidence.of(0.5);
+    static final Confidence POWER_WITH_COMPANIONS = Confidence.of(0.4);
+
+    private static final LinkId CORRELATOR_ID = LinkId.of("correlator");
+
+    private EventCorrelator() {}
+
+    public static AdvisoryReport evaluate(List<BeaconEvent> events, List<LinkHealth> snapshot) {
+        Objects.requireNonNull(events, "events");
+        Objects.requireNonNull(snapshot, "snapshot");
+        List<LinkHealth> failed = new ArrayList<>();
+        for (LinkHealth health : snapshot) {
+            Objects.requireNonNull(health, "health");
+            if (isFailed(health)) {
+                failed.add(health);
+            }
+        }
+        boolean amperVoltage = false;
+        for (BeaconEvent event : events) {
+            Objects.requireNonNull(event, "event");
+            if (event.type() == BeaconEventType.AMPER_VOLTAGE) {
+                amperVoltage = true;
+            }
+        }
+        List<AdvisoryEvidence> evidence = evidenceFrom(failed, events, amperVoltage);
+        Set<DomainFamily> families = familiesOf(failed);
+        if (amperVoltage) {
+            families.add(DomainFamily.POWER);
+        }
+        if (families.isEmpty()) {
+            return AdvisoryReport.of(
+                    AdvisoryLabel.INSUFFICIENT_EVIDENCE,
+                    Confidence.unknown(),
+                    evidence,
+                    "No STALE or LOST links and no AMPER voltage events. Nothing to classify.");
+        }
+        if (families.contains(DomainFamily.UNSUPPORTED)) {
+            return insufficient(
+                    evidence,
+                    "Snapshot includes a domain this correlator will not diagnose "
+                            + "(Driver Station, gamepad, or unknown). Prefer insufficient evidence.");
+        }
+        if (families.size() == 1) {
+            DomainFamily only = families.iterator().next();
+            if (only == DomainFamily.CAMERA) {
+                return AdvisoryReport.of(
+                        AdvisoryLabel.PROBABLE_ISOLATED_CAMERA_FAILURE,
+                        ISOLATED,
+                        evidence,
+                        "Only USB camera links are STALE or LOST. Other observed domains are not failed.");
+            }
+            if (only == DomainFamily.HUB_PATH) {
+                return AdvisoryReport.of(
+                        AdvisoryLabel.PROBABLE_EXPANSION_HUB_PATH_FAILURE,
+                        ISOLATED,
+                        evidence,
+                        "Only Expansion Hub path or sensor-bus links are STALE or LOST.");
+            }
+            if (only == DomainFamily.POWER) {
+                return AdvisoryReport.of(
+                        AdvisoryLabel.PROBABLE_POWER_DISRUPTION,
+                        ISOLATED,
+                        evidence,
+                        "Electrical or AMPER voltage evidence is present and no other domain family is failed.");
+            }
+            if (only == DomainFamily.LOOP) {
+                if (hasLoopOverrun(failed)) {
+                    return AdvisoryReport.of(
+                            AdvisoryLabel.PROBABLE_LOOP_OVERRUN,
+                            ISOLATED,
+                            evidence,
+                            "Only software-loop links are failed, and a LOOP_OVERRUN reason is present.");
+                }
+                return insufficient(
+                        evidence,
+                        "A software-loop link is STALE or LOST without a LOOP_OVERRUN reason. "
+                                + "Localization loss is not treated as a loop overrun.");
+            }
+        }
+        if (families.contains(DomainFamily.POWER) && families.size() > 1) {
+            return AdvisoryReport.of(
+                    AdvisoryLabel.PROBABLE_POWER_DISRUPTION,
+                    POWER_WITH_COMPANIONS,
+                    evidence,
+                    "Electrical or AMPER voltage evidence coincides with other failed domains. "
+                            + "Simultaneous failures can also be ESD or cabling; this is not a unique cause "
+                            + "and is not jamming.");
+        }
+        return insufficient(
+                evidence,
+                "More than one domain family is STALE or LOST without electrical or AMPER evidence. "
+                        + "Simultaneous failures are not treated as a single root cause.");
+    }
+
+    private static AdvisoryReport insufficient(List<AdvisoryEvidence> evidence, String explanation) {
+        return AdvisoryReport.of(
+                AdvisoryLabel.INSUFFICIENT_EVIDENCE, Confidence.unknown(), evidence, explanation);
+    }
+
+    private static boolean isFailed(LinkHealth health) {
+        return health.state() == LinkState.STALE || health.state() == LinkState.LOST;
+    }
+
+    private static boolean hasLoopOverrun(List<LinkHealth> failed) {
+        for (LinkHealth health : failed) {
+            if (health.domain() == FailureDomain.SOFTWARE_LOOP
+                    && health.reason() == LinkFailureReason.LOOP_OVERRUN) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<DomainFamily> familiesOf(List<LinkHealth> failed) {
+        Set<DomainFamily> families = new LinkedHashSet<>();
+        for (LinkHealth health : failed) {
+            families.add(familyOf(health.domain()));
+        }
+        return families;
+    }
+
+    private static DomainFamily familyOf(FailureDomain domain) {
+        switch (domain) {
+            case USB_CAMERA:
+                return DomainFamily.CAMERA;
+            case CONTROL_HUB_TO_EXPANSION_HUB:
+            case SENSOR_BUS:
+                return DomainFamily.HUB_PATH;
+            case ELECTRICAL:
+                return DomainFamily.POWER;
+            case SOFTWARE_LOOP:
+                return DomainFamily.LOOP;
+            case GAMEPAD_TO_DRIVER_HUB:
+            case DRIVER_STATION_TO_ROBOT_CONTROLLER:
+            case ROBOT_CONTROLLER_TO_CONTROL_HUB_IO:
+            case UNKNOWN:
+            default:
+                return DomainFamily.UNSUPPORTED;
+        }
+    }
+
+    private static List<AdvisoryEvidence> evidenceFrom(
+            List<LinkHealth> failed, List<BeaconEvent> events, boolean amperVoltage) {
+        List<AdvisoryEvidence> evidence = new ArrayList<>();
+        for (LinkHealth health : failed) {
+            evidence.add(new AdvisoryEvidence(
+                    health.id(),
+                    health.domain(),
+                    health.state().name() + " " + health.reason().name()));
+        }
+        for (BeaconEvent event : events) {
+            if (event.type() == BeaconEventType.AMPER_VOLTAGE) {
+                LinkId id = event.linkId() == null ? LinkId.of("amper") : event.linkId();
+                evidence.add(new AdvisoryEvidence(
+                        id, event.domain(), event.type().name() + " " + event.detail()));
+            }
+        }
+        if (evidence.isEmpty()) {
+            evidence.add(new AdvisoryEvidence(
+                    CORRELATOR_ID,
+                    FailureDomain.UNKNOWN,
+                    "No failed links and no AMPER voltage events in the provided window."));
+        } else if (amperVoltage && failed.size() > 1) {
+            evidence.add(new AdvisoryEvidence(
+                    CORRELATOR_ID,
+                    FailureDomain.ELECTRICAL,
+                    "Multiple domain families failed in the same window; do not treat that as jamming."));
+        }
+        return Collections.unmodifiableList(evidence);
+    }
+
+    private enum DomainFamily {
+        CAMERA,
+        HUB_PATH,
+        POWER,
+        LOOP,
+        UNSUPPORTED
+    }
+}

--- a/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
+++ b/src/test/java/org/allsparks/beacon/BeaconSessionTest.java
@@ -7,11 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 import org.allsparks.beacon.adapters.future.SystemCoreAdapterBoundary;
+import org.allsparks.beacon.api.Confidence;
 import org.allsparks.beacon.api.FailureDomain;
 import org.allsparks.beacon.api.HealthReport;
+import org.allsparks.beacon.api.LinkFailureReason;
 import org.allsparks.beacon.api.LinkId;
 import org.allsparks.beacon.api.LinkState;
 import org.allsparks.beacon.clock.FakeClock;
+import org.allsparks.beacon.correlate.AdvisoryLabel;
+import org.allsparks.beacon.correlate.AdvisoryReport;
 import org.allsparks.beacon.preflight.PreflightExpectation;
 import org.allsparks.beacon.preflight.PreflightFinding;
 import org.allsparks.beacon.preflight.PreflightStatus;
@@ -102,6 +106,48 @@ class BeaconSessionTest {
                                 PreflightExpectation.required(LinkId.of("frontCamera")),
                                 PreflightExpectation.optional(LinkId.of("expansionHub"))))
                         .status());
+        assertTrue(session.logger().size() >= 1);
+        assertFalse(session.isInterventionEnabled());
+        assertFalse(session.flags().isPhase5DrivetrainSafeStop());
+    }
+
+    @Test
+    void advisoryDisabledFailsInsufficient() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.defaults(), clock, 16);
+        session.report(new HealthReport(
+                LinkId.of("frontCamera"),
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                1L,
+                "ViDAR",
+                "pipeline stopped",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.8)));
+        AdvisoryReport report = session.advise();
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+        assertEquals(0, session.logger().size());
+        assertFalse(session.isInterventionEnabled());
+    }
+
+    @Test
+    void advisoryEnabledLabelsIsolatedCameraAndDoesNotCommand() {
+        FakeClock clock = new FakeClock(1L);
+        BeaconSession session = new BeaconSession(BeaconFeatureFlags.advisory(), clock, 16);
+        session.report(new HealthReport(
+                LinkId.of("frontCamera"),
+                FailureDomain.USB_CAMERA,
+                LinkState.LOST,
+                1L,
+                "ViDAR",
+                "pipeline stopped",
+                LinkFailureReason.EXPLICIT_LOSS_REPORT,
+                Confidence.of(0.8)));
+        AdvisoryReport report = session.advise();
+        assertEquals(AdvisoryLabel.PROBABLE_ISOLATED_CAMERA_FAILURE, report.label());
+        assertTrue(report.confidence().isKnown());
+        assertFalse(report.evidence().isEmpty());
         assertTrue(session.logger().size() >= 1);
         assertFalse(session.isInterventionEnabled());
         assertFalse(session.flags().isPhase5DrivetrainSafeStop());

--- a/src/test/java/org/allsparks/beacon/correlate/EventCorrelatorTest.java
+++ b/src/test/java/org/allsparks/beacon/correlate/EventCorrelatorTest.java
@@ -1,0 +1,145 @@
+package org.allsparks.beacon.correlate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.allsparks.beacon.api.Confidence;
+import org.allsparks.beacon.api.FailureDomain;
+import org.allsparks.beacon.api.LinkFailureReason;
+import org.allsparks.beacon.api.LinkHealth;
+import org.allsparks.beacon.api.LinkId;
+import org.allsparks.beacon.api.LinkState;
+import org.allsparks.beacon.log.BeaconEvent;
+import org.allsparks.beacon.log.BeaconEventType;
+import org.junit.jupiter.api.Test;
+
+class EventCorrelatorTest {
+    private static final LinkId CAMERA = LinkId.of("frontCamera");
+    private static final LinkId HUB = LinkId.of("expansionHub");
+    private static final LinkId BATTERY = LinkId.of("batteryTelemetry");
+    private static final LinkId LOCALIZATION = LinkId.of("localization");
+
+    @Test
+    void emptySnapshotIsInsufficient() {
+        AdvisoryReport report = EventCorrelator.evaluate(Collections.emptyList(), Collections.emptyList());
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+        assertFalse(report.evidence().isEmpty());
+        assertFalse(report.explanation().trim().isEmpty());
+    }
+
+    @Test
+    void healthyLinksAreInsufficient() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(), Collections.singletonList(healthy(CAMERA, FailureDomain.USB_CAMERA)));
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+    }
+
+    @Test
+    void isolatedCameraLossIsProbableCamera() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(), Collections.singletonList(lost(CAMERA, FailureDomain.USB_CAMERA)));
+        assertEquals(AdvisoryLabel.PROBABLE_ISOLATED_CAMERA_FAILURE, report.label());
+        assertEquals(EventCorrelator.ISOLATED, report.confidence());
+        assertEquals(CAMERA, report.evidence().get(0).linkId());
+    }
+
+    @Test
+    void isolatedHubLossIsProbableHubPath() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(),
+                Collections.singletonList(lost(HUB, FailureDomain.CONTROL_HUB_TO_EXPANSION_HUB)));
+        assertEquals(AdvisoryLabel.PROBABLE_EXPANSION_HUB_PATH_FAILURE, report.label());
+        assertEquals(EventCorrelator.ISOLATED, report.confidence());
+    }
+
+    @Test
+    void isolatedElectricalIsProbablePower() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(), Collections.singletonList(lost(BATTERY, FailureDomain.ELECTRICAL)));
+        assertEquals(AdvisoryLabel.PROBABLE_POWER_DISRUPTION, report.label());
+        assertEquals(EventCorrelator.ISOLATED, report.confidence());
+    }
+
+    @Test
+    void loopOverrunReasonIsProbableLoopOverrun() {
+        LinkHealth loop = LinkHealth.builder(LOCALIZATION)
+                .domain(FailureDomain.SOFTWARE_LOOP)
+                .state(LinkState.LOST)
+                .reason(LinkFailureReason.LOOP_OVERRUN)
+                .confidence(Confidence.of(0.7))
+                .build();
+        AdvisoryReport report = EventCorrelator.evaluate(Collections.emptyList(), Collections.singletonList(loop));
+        assertEquals(AdvisoryLabel.PROBABLE_LOOP_OVERRUN, report.label());
+        assertEquals(EventCorrelator.ISOLATED, report.confidence());
+    }
+
+    @Test
+    void localizationLossWithoutOverrunIsInsufficient() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(),
+                Collections.singletonList(lost(LOCALIZATION, FailureDomain.SOFTWARE_LOOP)));
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+    }
+
+    @Test
+    void simultaneousCameraAndHubWithoutPowerIsInsufficient() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(),
+                Arrays.asList(
+                        lost(CAMERA, FailureDomain.USB_CAMERA),
+                        lost(HUB, FailureDomain.CONTROL_HUB_TO_EXPANSION_HUB)));
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+        assertTrue(report.evidence().size() >= 2);
+        assertTrue(report.explanation().toLowerCase().contains("simultaneous"));
+    }
+
+    @Test
+    void voltageEventWithCompanionFailuresIsLowConfidencePowerNotJamming() {
+        BeaconEvent voltage = new BeaconEvent(
+                1L, BeaconEventType.AMPER_VOLTAGE, BATTERY, FailureDomain.ELECTRICAL, "cliff");
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.singletonList(voltage),
+                Arrays.asList(
+                        lost(CAMERA, FailureDomain.USB_CAMERA),
+                        lost(HUB, FailureDomain.CONTROL_HUB_TO_EXPANSION_HUB)));
+        assertEquals(AdvisoryLabel.PROBABLE_POWER_DISRUPTION, report.label());
+        assertEquals(EventCorrelator.POWER_WITH_COMPANIONS, report.confidence());
+        assertTrue(report.explanation().toLowerCase().contains("jamming"));
+        assertFalse(report.explanation().toLowerCase().contains("jammed and"));
+    }
+
+    @Test
+    void driverStationDomainIsInsufficientNotAHeartbeat() {
+        AdvisoryReport report = EventCorrelator.evaluate(
+                Collections.emptyList(),
+                Collections.singletonList(
+                        lost(LinkId.of("driverStation"), FailureDomain.DRIVER_STATION_TO_ROBOT_CONTROLLER)));
+        assertEquals(AdvisoryLabel.INSUFFICIENT_EVIDENCE, report.label());
+        assertFalse(report.confidence().isKnown());
+    }
+
+    private static LinkHealth healthy(LinkId id, FailureDomain domain) {
+        return LinkHealth.builder(id)
+                .domain(domain)
+                .state(LinkState.HEALTHY)
+                .reason(LinkFailureReason.NONE)
+                .confidence(Confidence.of(1.0))
+                .build();
+    }
+
+    private static LinkHealth lost(LinkId id, FailureDomain domain) {
+        return LinkHealth.builder(id)
+                .domain(domain)
+                .state(LinkState.LOST)
+                .reason(LinkFailureReason.EXPLICIT_LOSS_REPORT)
+                .confidence(Confidence.of(0.8))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 now classifies a health snapshot plus event timeline into **one** advisory label with confidence and evidence. This is not a root-cause engine and does not change outputs.

Part of #17. Does **not** close #17: post-match false-fault review and sibling ViDAR/MIMIC/AMPER/Pedro adapters remain. Shadow safe-stop logging remains #18.

## Problem

Teams needed evidence-based labels instead of stories like “jamming.” Phase 3 history existed, but nothing joined it into an advisory classification.

## Solution

- `EventCorrelator.evaluate(events, snapshot)`
- Isolated camera / hub-path / electrical / `LOOP_OVERRUN` → probable label at confidence `0.5`
- Software-loop loss without `LOOP_OVERRUN` → `INSUFFICIENT_EVIDENCE`
- Driver Station / gamepad domains → `INSUFFICIENT_EVIDENCE` (not a heartbeat detector)
- Multi-family failures without electrical or AMPER voltage evidence → `INSUFFICIENT_EVIDENCE`
- AMPER voltage or electrical plus other failures → `PROBABLE_POWER_DISRUPTION` at `0.4`, with all evidence; not a unique cause; not jamming
- No jamming label exists
- `BeaconSession.advise()` is off unless `BeaconFeatureFlags.advisory()` is set
- Flag off returns `INSUFFICIENT_EVIDENCE` with unknown confidence

## Scope

- Correlator types, session entry point, unit tests (including simultaneous-failure fixtures), docs/examples

## Out of scope

- Sibling library adapters (#11–#14)
- Match false-fault review (#17 remaining AC)
- Shadow `SAFE_STOP` logging (#18)
- Actuator writes
- Capturing other teams’ Wi-Fi

## Test plan

- [x] Empty / healthy snapshot → insufficient, unknown confidence
- [x] Isolated camera, hub, electrical, loop-overrun
- [x] Localization loss without overrun → insufficient
- [x] Camera + hub without AMPER → insufficient
- [x] AMPER voltage + companions → low-confidence power, not jamming
- [x] Driver Station domain → insufficient
- [x] Session flag off is silent; flag on does not enable intervention
- [ ] GitHub Actions `check` on Ubuntu and Windows
- [ ] Docs-structure relative links